### PR TITLE
add role based query for users

### DIFF
--- a/backend/rest/userRoutes.ts
+++ b/backend/rest/userRoutes.ts
@@ -12,9 +12,10 @@ import UserService from "../services/implementations/userService";
 import IAuthService from "../services/interfaces/authService";
 import IEmailService from "../services/interfaces/emailService";
 import IUserService from "../services/interfaces/userService";
-import { UserDTO } from "../types/userTypes";
+import { UserDTO, isRole } from "../types/userTypes";
 import { getErrorMessage } from "../utilities/errorUtils";
 import { sendResponseByMimeType } from "../utilities/responseUtil";
+import { capitalizeFirstLetter } from "../utilities/StringUtils";
 
 const userRouter: Router = Router();
 userRouter.use(isAuthorizedByRole(new Set(["Administrator"])));
@@ -161,6 +162,20 @@ userRouter.delete("/", async (req, res) => {
   res
     .status(400)
     .json({ error: "Must supply one of userId or email as query parameter." });
+});
+
+userRouter.get("/:role", async (req, res) => {
+  try {
+    const captializedRole = capitalizeFirstLetter(req.params.role);
+    if (isRole(captializedRole)) {
+      const users = await userService.getUsersByRole(captializedRole);
+      res.status(200).json(users);
+    } else {
+      res.status(400).json({ error: `Invalid role` });
+    }
+  } catch (error: unknown) {
+    res.status(500).json({ error: getErrorMessage(error) });
+  }
 });
 
 export default userRouter;

--- a/backend/services/interfaces/userService.ts
+++ b/backend/services/interfaces/userService.ts
@@ -91,6 +91,13 @@ interface IUserService {
    * @throws Error if user deletion fails
    */
   deleteUserByEmail(email: string): Promise<void>;
+
+  /**
+   * Gets all user that belong to the role
+   * @param role the role that we want to get
+   * @returns an Array of UserDtos that all have the corresponding role
+   */
+  getUsersByRole(role: Role): Promise<Array<UserDTO>>;
 }
 
 export default IUserService;

--- a/backend/types/userTypes.ts
+++ b/backend/types/userTypes.ts
@@ -13,3 +13,9 @@ export type CreateUserDTO = Omit<UserDTO, "id"> & { password: string };
 export type UpdateUserDTO = Omit<UserDTO, "id">;
 
 export type SignupUserDTO = Omit<CreateUserDTO, "role">;
+
+export function isRole(role: string): role is Role {
+  return (
+    role === "Administrator" || role === "Facilitator" || role === "Learner"
+  );
+}

--- a/backend/utilities/StringUtils.ts
+++ b/backend/utilities/StringUtils.ts
@@ -1,0 +1,4 @@
+// eslint-disable-next-line import/prefer-default-export
+export function capitalizeFirstLetter(string: string): string {
+  return string.charAt(0).toUpperCase() + string.slice(1);
+}


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Ticket Name](https://www.notion.so/uwblueprintexecs/7e51fde5f22d448b8226f2cfa4dd93d5?v=b2dc0dba06574651a8b6063bdd0d74e0&p=f7704d5b76f446caa7a70319d1ec6bc4&pm=s)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Allows for users to query for users based on one of the three roles at /users/:role


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. In postman, obtain the bearer token and use for the request to /users/:role
2. Try making a request to any of the three roles (doesn't need to be capitalized), should get a list of users
3. Try making a request without a role (Should get invalid role)
4. Try making a request with a role that isn't one of the three (Same response as above)


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* 


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
