### PR TITLE
Add My User Account Info Page

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -26,6 +26,7 @@ import HooksDemo from "./components/pages/HooksDemo";
 import { AuthenticatedUser } from "./types/AuthTypes";
 import authAPIClient from "./APIClients/AuthAPIClient";
 import * as Routes from "./constants/Routes";
+import MyAccount from "./components/pages/MyAccount";
 
 const App = (): React.ReactElement => {
   const currentUser: AuthenticatedUser = getLocalStorageObj<AuthenticatedUser>(
@@ -75,6 +76,12 @@ const App = (): React.ReactElement => {
                 exact
                 path={Routes.HOME_PAGE}
                 component={Default}
+                allowedRoles={["Administrator", "Facilitator", "Learner"]}
+              />
+              <PrivateRoute
+                exact
+                path={Routes.MY_ACCOUNT_PAGE}
+                component={MyAccount}
                 allowedRoles={["Administrator", "Facilitator", "Learner"]}
               />
               <PrivateRoute

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,6 +12,7 @@ import DisplayPage from "./components/pages/DisplayPage";
 import NotFound from "./components/pages/NotFound";
 import NotAuthorized from "./components/pages/NotAuthorized";
 import UpdatePage from "./components/pages/UpdatePage";
+import MyAccount from "./components/pages/MyAccount";
 import AUTHENTICATED_USER_KEY from "./constants/AuthConstants";
 import AuthContext from "./contexts/AuthContext";
 import { getLocalStorageObj } from "./utils/LocalStorageUtils";
@@ -26,7 +27,6 @@ import HooksDemo from "./components/pages/HooksDemo";
 import { AuthenticatedUser } from "./types/AuthTypes";
 import authAPIClient from "./APIClients/AuthAPIClient";
 import * as Routes from "./constants/Routes";
-import MyAccount from "./components/pages/MyAccount";
 
 const App = (): React.ReactElement => {
   const currentUser: AuthenticatedUser = getLocalStorageObj<AuthenticatedUser>(

--- a/frontend/src/components/pages/Default.tsx
+++ b/frontend/src/components/pages/Default.tsx
@@ -50,6 +50,7 @@ const Default = (): React.ReactElement => {
         <Button text="Display Entities" path={Routes.DISPLAY_ENTITY_PAGE} />
         <Button text="Edit Team" path={Routes.EDIT_TEAM_PAGE} />
         <Button text="Hooks Demo" path={Routes.HOOKS_PAGE} />
+        <Button text="My Account" path={Routes.MY_ACCOUNT_PAGE} />
       </div>
 
       <div style={{ height: "2rem" }} />

--- a/frontend/src/components/pages/MyAccount.tsx
+++ b/frontend/src/components/pages/MyAccount.tsx
@@ -2,18 +2,19 @@ import React, { useContext } from "react";
 import MainPageButton from "../common/MainPageButton";
 import AuthContext from "../../contexts/AuthContext";
 
-
 const MyAccount = (): React.ReactElement => {
-    const { authenticatedUser } = useContext(AuthContext);
-    return (
-        <div style={{ textAlign: "center", width: "25%", margin: "0px auto" }}>
-            <h1>My Account</h1>
-            <div>First Name: {authenticatedUser?.firstName}</div>
-            <div>Last Name: {authenticatedUser?.lastName}</div>
-            <div style={{ marginBottom: "1rem" }}>Email: {authenticatedUser?.email}</div>
-            <MainPageButton />
-        </div>
-    );
+  const { authenticatedUser } = useContext(AuthContext);
+  return (
+    <div style={{ textAlign: "center", width: "25%", margin: "0px auto" }}>
+      <h1>My Account</h1>
+      <div>First Name: {authenticatedUser?.firstName}</div>
+      <div>Last Name: {authenticatedUser?.lastName}</div>
+      <div style={{ marginBottom: "1rem" }}>
+        Email: {authenticatedUser?.email}
+      </div>
+      <MainPageButton />
+    </div>
+  );
 };
 
 export default MyAccount;

--- a/frontend/src/components/pages/MyAccount.tsx
+++ b/frontend/src/components/pages/MyAccount.tsx
@@ -1,0 +1,19 @@
+import React, { useContext } from "react";
+import MainPageButton from "../common/MainPageButton";
+import AuthContext from "../../contexts/AuthContext";
+
+
+const MyAccount = (): React.ReactElement => {
+    const { authenticatedUser } = useContext(AuthContext);
+    return (
+        <div style={{ textAlign: "center", width: "25%", margin: "0px auto" }}>
+            <h1>My Account</h1>
+            <div>First Name: {authenticatedUser?.firstName}</div>
+            <div>Last Name: {authenticatedUser?.lastName}</div>
+            <div style={{ marginBottom: "1rem" }}>Email: {authenticatedUser?.email}</div>
+            <MainPageButton />
+        </div>
+    );
+};
+
+export default MyAccount;

--- a/frontend/src/constants/Routes.ts
+++ b/frontend/src/constants/Routes.ts
@@ -17,3 +17,5 @@ export const HOOKS_PAGE = "/hooks";
 export const WELCOME_PAGE = "/welcome";
 
 export const NOT_AUTHORIZED_PAGE = "/not-authorized";
+
+export const MY_ACCOUNT_PAGE = "/account";


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[User Account Page](https://www.notion.so/uwblueprintexecs/User-Account-Page-2250e1cb67c0428cb33849944e3bb610)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Added a button in the navbar for "My Account" which takes you to the account info page at `/account`
* The account info page shows the info for your account taken from `authenticatedUser`.
* A private route was used to ensure that a user is logged in.

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Press the "My Account" button in the navbar. 
2. See if your account info appears on the screen
3. Try going to the page without being logged in and see if you are redirected to the login page.


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Functionality and style of code.


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
