### PR TITLE
add script to delete users that are in only 1 of firebase or mongodb

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -9,7 +9,7 @@
     "lint": "eslint . --ext .ts,.js",
     "fix": "eslint . --ext .ts,.js --fix",
     "postinstall": "tsc",
-    "sync": "ts-node ./scripts/sync-databases.ts"
+    "sync-user-dbs": "ts-node ./scripts/sync-user-databases.ts"
   },
   "keywords": [],
   "author": "",

--- a/backend/package.json
+++ b/backend/package.json
@@ -8,7 +8,8 @@
     "dev": "nodemon -L",
     "lint": "eslint . --ext .ts,.js",
     "fix": "eslint . --ext .ts,.js --fix",
-    "postinstall": "tsc"
+    "postinstall": "tsc",
+    "sync": "ts-node ./scripts/sync-databases.ts"
   },
   "keywords": [],
   "author": "",

--- a/backend/scripts/sync-databases.ts
+++ b/backend/scripts/sync-databases.ts
@@ -1,0 +1,101 @@
+import * as firebaseAdmin from "firebase-admin";
+import dotenv from "dotenv";
+import MgUser, { User } from "../models/user.mgmodel";
+import logger from "../utilities/logger";
+import { getErrorMessage } from "../utilities/errorUtils";
+import { mongo } from "../models";
+
+dotenv.config();
+
+const Logger = logger(__filename);
+
+firebaseAdmin.initializeApp({
+  credential: firebaseAdmin.credential.cert({
+    projectId: process.env.FIREBASE_PROJECT_ID,
+    privateKey: process.env.FIREBASE_SVC_ACCOUNT_PRIVATE_KEY?.replace(
+      /\\n/g,
+      "\n",
+    ),
+    clientEmail: process.env.FIREBASE_SVC_ACCOUNT_CLIENT_EMAIL,
+  }),
+});
+
+mongo.connect();
+
+async function getAllFirebaseUsers(
+  nextPageToken?: string,
+): Promise<firebaseAdmin.auth.UserRecord[]> {
+  const listUsersResult = await firebaseAdmin
+    .auth()
+    .listUsers(1000, nextPageToken);
+  const { users } = listUsersResult;
+
+  // If there are more users to fetch, recursively fetch them.
+  if (listUsersResult.pageToken) {
+    const moreUsers = await getAllFirebaseUsers(listUsersResult.pageToken);
+    return users.concat(moreUsers);
+  }
+  return users;
+}
+
+async function getUsersNotInFirebase(
+  allFirebaseUsers: firebaseAdmin.auth.UserRecord[],
+  allMongoDBUsers: User[],
+): Promise<string[]> {
+  // We are checking Firebase for all the MongoDB users not in there
+
+  const allFirebaseUserIds = allFirebaseUsers.map((user) => user.uid);
+  const allMongoDBUserIds = new Set(allMongoDBUsers.map((user) => user.authId));
+
+  // put in the ! to not delete the wrong people
+  return allFirebaseUserIds.filter((id) => !allMongoDBUserIds.has(id));
+}
+
+async function getUsersNotInMongoDB(
+  allFirebaseUsers: firebaseAdmin.auth.UserRecord[],
+  allMongoDBUsers: User[],
+) {
+  // We are checking MongoDB for all the Firebase users not in there
+  const allFirebaseUserIds = new Set(allFirebaseUsers.map((user) => user.uid));
+  const allMongoDBUserIds = allMongoDBUsers.map((user) => user.authId);
+  // put in the ! to not delete the wrong people
+  return allMongoDBUserIds.filter((id) => !allFirebaseUserIds.has(id));
+}
+
+async function main() {
+  try {
+    const allFirebaseUsers = await getAllFirebaseUsers();
+    Logger.info(`Found ${allFirebaseUsers.length} firebase users`);
+
+    const allMongoDBUsers = await MgUser.find();
+    Logger.info(`Found ${allMongoDBUsers.length} MongoDB users`);
+
+    const removeMongoDBUsers = await getUsersNotInMongoDB(
+      allFirebaseUsers,
+      allMongoDBUsers,
+    );
+    const removeFirebaseUsers = await getUsersNotInFirebase(
+      allFirebaseUsers,
+      allMongoDBUsers,
+    );
+
+    // Comment if you dont actually want to delete
+
+    removeMongoDBUsers.forEach(async (id) => {
+      await MgUser.deleteOne({ authId: id });
+    });
+
+    removeFirebaseUsers.forEach(async (id) => {
+      await firebaseAdmin.auth().deleteUser(id);
+    });
+    Logger.info(
+      `Deleted ${removeMongoDBUsers.length} MongoDB users and ${removeFirebaseUsers.length} Firebase users`,
+    );
+    return;
+  } catch (error: unknown) {
+    Logger.error(getErrorMessage(error));
+    throw error;
+  }
+}
+
+main();

--- a/backend/scripts/sync-user-databases.ts
+++ b/backend/scripts/sync-user-databases.ts
@@ -38,7 +38,7 @@ async function getAllFirebaseUsers(
   return users;
 }
 
-async function getUsersNotInFirebase(
+async function getUsersNotInMongoDB(
   allFirebaseUsers: firebaseAdmin.auth.UserRecord[],
   allMongoDBUsers: User[],
 ): Promise<string[]> {
@@ -51,7 +51,7 @@ async function getUsersNotInFirebase(
   return allFirebaseUserIds.filter((id) => !allMongoDBUserIds.has(id));
 }
 
-async function getUsersNotInMongoDB(
+async function getUsersNotInFirebase(
   allFirebaseUsers: firebaseAdmin.auth.UserRecord[],
   allMongoDBUsers: User[],
 ) {
@@ -91,7 +91,7 @@ async function main() {
     Logger.info(
       `Deleted ${removeMongoDBUsers.length} MongoDB users and ${removeFirebaseUsers.length} Firebase users`,
     );
-    return;
+    process.exit();
   } catch (error: unknown) {
     Logger.error(getErrorMessage(error));
     throw error;


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Ticket Name] ~There is no ticket~
https://www.notion.so/uwblueprintexecs/Sync-User-Databases-Script-f1015fcca2e6476eb3f9dd51299dcb03?pvs=4


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Added a backend script to delete users that are only in Firebase or only in MongoDB (if there is a de-sync, it messes up some queries for get users by roles) 


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Ideally you don't run this on the dev server like I did and run it on a different mongodb and firebase database instead
2. If you don't want to do that, comment out the delete lines first to check if everything looks right by the numbers
3. In the backend directory, run "npm run sync"


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* 


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
