### PR TITLE
[DO NOT MERGE] Carolyn/error refactor

### DIFF
--- a/backend/services/implementations/authService.ts
+++ b/backend/services/implementations/authService.ts
@@ -27,11 +27,11 @@ class AuthService implements IAuthService {
   /* eslint-disable class-methods-use-this */
   async generateToken(email: string, password: string): Promise<AuthDTO> {
     try {
+      const user = await this.userService.getUserByEmail(email);
       const token = await FirebaseRestClient.signInWithPassword(
         email,
         password,
       );
-      const user = await this.userService.getUserByEmail(email);
       return { ...token, ...user };
     } catch (error) {
       Logger.error(`Failed to generate token for user with email ${email}`);

--- a/backend/services/implementations/userService.ts
+++ b/backend/services/implementations/userService.ts
@@ -62,7 +62,7 @@ class UserService implements IUserService {
       }
     } catch (error: unknown) {
       Logger.error(`Failed to get user. Reason = ${getErrorMessage(error)}`);
-      throw error;
+      throw new Error("EMAIL_NOT_FOUND");
     }
 
     return {

--- a/frontend/src/APIClients/AuthAPIClient.ts
+++ b/frontend/src/APIClients/AuthAPIClient.ts
@@ -1,3 +1,4 @@
+import { AxiosError } from "axios";
 import AUTHENTICATED_USER_KEY from "../constants/AuthConstants";
 import { AuthenticatedUser } from "../types/AuthTypes";
 import baseAPIClient from "./BaseAPIClient";
@@ -18,6 +19,9 @@ const login = async (
     );
     return data;
   } catch (error) {
+    if (error instanceof AxiosError) {
+      throw new Error(error.response?.data.error);
+    }
     return null;
   }
 };

--- a/frontend/src/errors/AuthErrors.ts
+++ b/frontend/src/errors/AuthErrors.ts
@@ -1,0 +1,29 @@
+import { PresentableError } from "../types/ErrorTypes";
+
+export const authErrors: Record<string, PresentableError> = {
+  INVALID_LOGIN_CREDENTIALS: {
+    title: () => "Invalid login credentials",
+    text: () => "Please check your email and password, and try again.",
+  },
+  UNVERIFIED_EMAIL: {
+    title: () => "Unverified email",
+    text: () =>
+      "Please check your email and click on the link to verify your email.",
+  },
+  WRONG_USER_TYPE: {
+    title: () => "Wrong user type",
+    text: (wrongRole, correctRole) =>
+      `It looks like you're trying to log in with the wrong account type (${wrongRole}). Please select the correct user type (${correctRole}) and try again.`,
+  },
+  EMAIL_NOT_FOUND: {
+    text: () => "Email not found. Please try again.",
+  },
+  INCORRECT_PASSWORD: {
+    text: () => "Incorrect password. Please try again.",
+  },
+};
+
+export const defaultAuthError: PresentableError = {
+  title: () => "An error occurred",
+  text: () => "Something went wrong. Please try again later.",
+};

--- a/frontend/src/types/ErrorTypes.ts
+++ b/frontend/src/types/ErrorTypes.ts
@@ -1,0 +1,4 @@
+export type PresentableError = {
+  title?: (...data: string[]) => string;
+  text: (...data: string[]) => string;
+};


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Error Refactor](https://www.notion.so/uwblueprintexecs/Error-Refactor-Wrong-Password-21b8efcdd2d44e529a607093bb9029a2)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
This is for pushing custom error handling into the backend and decoding it in the frontend for presentation to users. 

Here's the idea:
* Custom error handling logic is handled by the backend and specific error codes are returned, e.g. `{ error: "INCORRECT_PASSWORD" }` in the error response body. If we return back an error outside of the presentable error codes, these will later be suppressed by the frontend.
* In the frontend, we have an `authErrors` object that maps from error code to a presentable error. All other errors given from the backend will be substituted for `defaultAuthError`. - See `frontend/src/errors/AuthErrors.ts`
* In `frontend/src/types/ErrorTypes.ts`, the `PresentableError` type has props that are functions with variable arguments. This allows us to inject custom data into our error messages, e.g. in `WRONG_USER_TYPE` we want to tell the user what type they accidentally tried to log in as. The backend should throw the necessary data alongside the error in this case.



<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
This PR comes with an example of supporting `EMAIL_NOT_FOUND`.
* Backend: errors thrown in `backend/services/implementations/userService.ts`.
* Frontend: setting error state variables on login click in `frontend/src/components/auth/Login.tsx` by decoding error from API Client. sorry bout janky UI lol

1. Try logging in with an email that doesn't belong to any account in our app. You should see an "Email not found. Please try again." error under the email input.
2. Try killing your backend (or anything else that'll produce a different kind of error) and then clicking "Log In".  You should get "An error occurred" blahblah. This is the default error message.


## Checklist
- [ ] My PR name is descriptive and in imperative tense
- [ ] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [ ] I have run the appropriate linter(s)
- [ ] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
