### PR TITLE
add course unit sidebar

### DIFF
--- a/frontend/src/APIClients/CourseAPIClient.ts
+++ b/frontend/src/APIClients/CourseAPIClient.ts
@@ -1,0 +1,22 @@
+import AUTHENTICATED_USER_KEY from "../constants/AuthConstants";
+import { CourseUnit } from "../types/CourseTypes";
+import { getLocalStorageObjProperty } from "../utils/LocalStorageUtils";
+import baseAPIClient from "./BaseAPIClient";
+
+const getUnits = async (): Promise<CourseUnit[]> => {
+  const bearerToken = `Bearer ${getLocalStorageObjProperty(
+    AUTHENTICATED_USER_KEY,
+    "accessToken",
+  )}`;
+  try {
+    const { data } = await baseAPIClient.get("/course/", {
+      headers: { Authorization: bearerToken },
+    });
+    console.log(data)
+    return data;
+  } catch (error) {
+    return [];
+  }
+};
+
+export default { getUnits };

--- a/frontend/src/APIClients/CourseAPIClient.ts
+++ b/frontend/src/APIClients/CourseAPIClient.ts
@@ -12,7 +12,6 @@ const getUnits = async (): Promise<CourseUnit[]> => {
     const { data } = await baseAPIClient.get("/course/", {
       headers: { Authorization: bearerToken },
     });
-    console.log(data)
     return data;
   } catch (error) {
     return [];

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -27,6 +27,7 @@ import { SocketProvider } from "./contexts/SocketContext";
 import MakeHelpRequestPage from "./components/pages/MakeHelpRequestPage";
 import ViewHelpRequestsPage from "./components/pages/ViewHelpRequestsPage";
 import HelpRequestPage from "./components/pages/HelpRequestPage";
+import CourseUnitsPage from "./components/pages/courses/CourseUnitsPage";
 
 const App = (): React.ReactElement => {
   const currentUser: AuthenticatedUser | null =
@@ -117,6 +118,12 @@ const App = (): React.ReactElement => {
                   path={`${Routes.VIEW_HELP_REQUESTS_PAGE}/:id`}
                   component={HelpRequestPage}
                   allowedRoles={["Facilitator"]}
+                />
+                <PrivateRoute
+                  exact
+                  path={Routes.COURSES_PAGE}
+                  component={CourseUnitsPage}
+                  allowedRoles={["Administrator", "Facilitator", "Learner"]}
                 />
                 <Route exact path="*" component={NotFound} />
               </Switch>

--- a/frontend/src/components/courses/UnitSidebar.tsx
+++ b/frontend/src/components/courses/UnitSidebar.tsx
@@ -1,0 +1,106 @@
+import React, { useState } from "react";
+import {
+  Box,
+  Button,
+  Divider,
+  Drawer,
+  List,
+  ListItemButton,
+  ListItemText,
+  useTheme,
+} from "@mui/material";
+import ArrowBackIosIcon from "@mui/icons-material/ArrowBackIos";
+import { CourseUnit } from "../../types/CourseTypes";
+import { neutral } from "../../theme/palette";
+
+interface UnitSideBarProps {
+  courseUnits: CourseUnit[];
+  handleClose: () => void;
+  open: boolean;
+}
+
+export default function UnitSidebar(props: UnitSideBarProps) {
+  const theme = useTheme();
+  const { courseUnits, handleClose, open } = props;
+
+  const [selectedIndex, setSelectedIndex] = useState(0);
+
+  const handleListItemClick = (
+    event: React.MouseEvent<HTMLDivElement, MouseEvent>,
+    index: number,
+  ) => {
+    setSelectedIndex(index);
+  };
+
+  return (
+    <Drawer
+      sx={{
+        width: "20%",
+        flexShrink: 0,
+        "& .MuiDrawer-paper": {
+          width: "20%",
+          boxSizing: "border-box",
+        },
+        display: open ? "block" : "none",
+      }}
+      variant="persistent"
+      anchor="left"
+      open={open}
+    >
+      <Box height="100%" sx={{ backgroundColor: theme.palette.neutral.light }}>
+        <Box
+          height="59px"
+          display="flex"
+          p="12px"
+          alignItems="center"
+          justifyContent="space-between"
+          fontWeight="700"
+          fontSize="16px"
+        >
+          Units
+          <Button
+            type="button"
+            sx={{
+              p: "8px",
+              fontSize: "12px",
+            }}
+            endIcon={<ArrowBackIosIcon />}
+            onClick={handleClose}
+          >
+            Close
+          </Button>
+        </Box>
+        <List sx={{ width: "100%" }}>
+          {courseUnits.map((course, index) => {
+            return (
+              <React.Fragment key={course.id}>
+                <ListItemButton
+                  sx={{
+                    py: "15px",
+                    px: "32px",
+                    backgroundColor:
+                      selectedIndex === index ? neutral[90] : "transparent",
+                  }}
+                  onClick={(event) => handleListItemClick(event, index)}
+                >
+                  <ListItemText
+                    disableTypography
+                    primary={`${course.displayIndex}. ${course.title}`}
+                    sx={
+                      selectedIndex === index
+                        ? theme.typography.titleMedium
+                        : theme.typography.bodyLarge
+                    }
+                  />
+                </ListItemButton>
+                {index !== courseUnits.length - 1 && (
+                  <Divider component="li" sx={{ color: "#FCF8F8" }} />
+                )}
+              </React.Fragment>
+            );
+          })}
+        </List>
+      </Box>
+    </Drawer>
+  );
+}

--- a/frontend/src/components/courses/UnitSidebar.tsx
+++ b/frontend/src/components/courses/UnitSidebar.tsx
@@ -2,14 +2,14 @@ import React, { useState } from "react";
 import {
   Box,
   Button,
-  Divider,
   Drawer,
   List,
+  ListItem,
   ListItemButton,
   ListItemText,
   useTheme,
 } from "@mui/material";
-import ArrowBackIosIcon from "@mui/icons-material/ArrowBackIos";
+import MenuOpenIcon from "@mui/icons-material/MenuOpen";
 import { CourseUnit } from "../../types/CourseTypes";
 import { neutral } from "../../theme/palette";
 
@@ -52,6 +52,7 @@ export default function UnitSidebar(props: UnitSideBarProps) {
           height="59px"
           display="flex"
           p="12px"
+          paddingLeft="20px"
           alignItems="center"
           justifyContent="space-between"
           fontWeight="700"
@@ -63,8 +64,10 @@ export default function UnitSidebar(props: UnitSideBarProps) {
             sx={{
               p: "8px",
               fontSize: "12px",
+              color: theme.palette.neutral.main,
+              lineHeight: "1.5",
             }}
-            endIcon={<ArrowBackIosIcon />}
+            endIcon={<MenuOpenIcon />}
             onClick={handleClose}
           >
             Close
@@ -73,8 +76,19 @@ export default function UnitSidebar(props: UnitSideBarProps) {
         <List sx={{ width: "100%" }}>
           {courseUnits.map((course, index) => {
             return (
-              <React.Fragment key={course.id}>
+              <ListItem
+                key={course.id}
+                disablePadding
+                sx={{
+                  borderBottom: 1,
+                  borderColor:
+                    index !== courseUnits.length - 1
+                      ? "#DBE4E7"
+                      : "transparent",
+                }}
+              >
                 <ListItemButton
+                  key={course.id}
                   sx={{
                     py: "15px",
                     px: "32px",
@@ -93,10 +107,7 @@ export default function UnitSidebar(props: UnitSideBarProps) {
                     }
                   />
                 </ListItemButton>
-                {index !== courseUnits.length - 1 && (
-                  <Divider component="li" sx={{ color: "#FCF8F8" }} />
-                )}
-              </React.Fragment>
+              </ListItem>
             );
           })}
         </List>

--- a/frontend/src/components/pages/courses/CourseUnitsPage.tsx
+++ b/frontend/src/components/pages/courses/CourseUnitsPage.tsx
@@ -1,17 +1,19 @@
 import React, { useEffect, useState } from "react";
-import { Box, Typography } from "@mui/material";
+import { Box, Button, Typography, useTheme } from "@mui/material";
+import MenuOpenIcon from "@mui/icons-material/MenuOpen";
 import UnitSidebar from "../../courses/UnitSidebar";
 import { CourseUnit } from "../../../types/CourseTypes";
 import CourseAPIClient from "../../../APIClients/CourseAPIClient";
 
 export default function CourseUnitsPage() {
+  const theme = useTheme();
   const [courseUnits, setCourseUnits] = useState<CourseUnit[]>([]);
 
   const [open, setOpen] = useState(true);
 
-  // const handleDrawerOpen = () => {
-  //   setOpen(true);
-  // };
+  const handleDrawerOpen = () => {
+    setOpen(true);
+  };
 
   const handleDrawerClose = () => {
     setOpen(false);
@@ -32,6 +34,28 @@ export default function CourseUnitsPage() {
         handleClose={handleDrawerClose}
         open={open}
       />
+      {!open && (
+        <Button
+          type="button"
+          sx={{
+            color: theme.palette.neutral.dark,
+            backgroundColor: theme.palette.neutral.light,
+            borderRadius: "4px",
+            width: "34px",
+            minWidth: "34px",
+            height: "34px",
+            padding: 0,
+          }}
+          onClick={handleDrawerOpen}
+        >
+          <MenuOpenIcon
+            sx={{
+              fontSize: "18px",
+            }}
+          />
+        </Button>
+      )}
+
       <Box sx={{ flexGrow: 1 }}>
         <Typography paragraph>
           Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do

--- a/frontend/src/components/pages/courses/CourseUnitsPage.tsx
+++ b/frontend/src/components/pages/courses/CourseUnitsPage.tsx
@@ -1,0 +1,54 @@
+import React, { useEffect, useState } from "react";
+import { Box, Typography } from "@mui/material";
+import UnitSidebar from "../../courses/UnitSidebar";
+import { CourseUnit } from "../../../types/CourseTypes";
+import CourseAPIClient from "../../../APIClients/CourseAPIClient";
+
+export default function CourseUnitsPage() {
+  const [courseUnits, setCourseUnits] = useState<CourseUnit[]>([]);
+
+  const [open, setOpen] = useState(true);
+
+  // const handleDrawerOpen = () => {
+  //   setOpen(true);
+  // };
+
+  const handleDrawerClose = () => {
+    setOpen(false);
+  };
+
+  useEffect(() => {
+    const getCouseUnits = async () => {
+      const data = await CourseAPIClient.getUnits();
+      setCourseUnits(data);
+    };
+    getCouseUnits();
+  }, []);
+
+  return (
+    <Box display="flex" width="100%" height="100%">
+      <UnitSidebar
+        courseUnits={courseUnits}
+        handleClose={handleDrawerClose}
+        open={open}
+      />
+      <Box sx={{ flexGrow: 1 }}>
+        <Typography paragraph>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+          eiusmod tempor incididunt ut labore et dolore magna aliqua. Rhoncus
+          dolor purus non enim praesent elementum facilisis leo vel. Risus at
+          ultrices mi tempus imperdiet. Semper risus in hendrerit gravida rutrum
+          quisque non tellus. Convallis convallis tellus id interdum velit
+          laoreet id donec ultrices. Odio morbi quis commodo odio aenean sed
+          adipiscing. Amet nisl suscipit adipiscing bibendum est ultricies
+          integer quis. Cursus euismod quis viverra nibh cras. Metus vulputate
+          eu scelerisque felis imperdiet proin fermentum leo. Mauris commodo
+          quis imperdiet massa tincidunt. Cras tincidunt lobortis feugiat
+          vivamus at augue. At augue eget arcu dictum varius duis at consectetur
+          lorem. Velit sed ullamcorper morbi tincidunt. Lorem donec massa sapien
+          faucibus et molestie ac.
+        </Typography>
+      </Box>
+    </Box>
+  );
+}

--- a/frontend/src/constants/Routes.ts
+++ b/frontend/src/constants/Routes.ts
@@ -18,4 +18,4 @@ export const MAKE_HELP_REQUEST_PAGE = "/ask-for-help";
 
 export const VIEW_HELP_REQUESTS_PAGE = "/help-requests";
 
-export const COURSES_PAGE = "/courses";
+export const COURSES_PAGE = "/course";

--- a/frontend/src/constants/Routes.ts
+++ b/frontend/src/constants/Routes.ts
@@ -17,3 +17,5 @@ export const MANAGE_USERS_PAGE = "/manage-users";
 export const MAKE_HELP_REQUEST_PAGE = "/ask-for-help";
 
 export const VIEW_HELP_REQUESTS_PAGE = "/help-requests";
+
+export const COURSES_PAGE = "/courses";

--- a/frontend/src/theme/palette.ts
+++ b/frontend/src/theme/palette.ts
@@ -1,20 +1,6 @@
 export type Color = `#${string}`;
 
-export type Palette = {
-  0: Color;
-  10: Color;
-  20: Color;
-  30: Color;
-  40: Color;
-  50: Color;
-  60: Color;
-  70: Color;
-  80: Color;
-  90: Color;
-  95: Color;
-  99: Color;
-  100: Color;
-};
+export type Palette = Record<number, Color>;
 
 // Defined in Figma Design Document
 export const learner: Palette = {
@@ -93,6 +79,7 @@ export const neutral: Palette = {
   80: "#C5C7C7",
   90: "#E1E3E3",
   95: "#F0F1F1",
+  98: "#F9F9F9",
   99: "#F7FDFF",
   100: "#FFFFFF",
 };

--- a/frontend/src/theme/theme.ts
+++ b/frontend/src/theme/theme.ts
@@ -5,7 +5,7 @@ import {
   TypographyOptions,
 } from "@mui/material/styles";
 import { TypographyStyleOptions } from "@mui/material/styles/createTypography";
-import { error, learner, administrator, facilitator } from "./palette";
+import { error, learner, administrator, facilitator, neutral } from "./palette";
 import "@fontsource/roboto";
 
 // adding custom attributes to palette
@@ -20,6 +20,8 @@ declare module "@mui/material/styles" {
 
     // Figma: tertiary colour palette
     facilitator: SimplePaletteColorOptions;
+
+    neutral: SimplePaletteColorOptions;
   }
 
   interface TypographyOptions {
@@ -102,6 +104,12 @@ const lightThemePalette: PaletteOptions = {
     light: error[90],
     dark: error[10],
   },
+
+  neutral: {
+    main: neutral[40],
+    light: neutral[98],
+    dark: neutral[10],
+  },
 };
 
 const darkThemePalette: PaletteOptions = {
@@ -126,101 +134,106 @@ const darkThemePalette: PaletteOptions = {
     light: error[30],
     dark: error[90],
   },
+  neutral: {
+    main: neutral[60],
+    light: neutral[10],
+    dark: neutral[90], // change these later
+  },
 };
 
 const typography: TypographyOptions = {
   displayLarge: {
-    fontSize: "57pt",
+    fontSize: "57px",
     fontWeight: 700,
-    lineHeight: "64pt",
-    letterSpacing: "-0.25pt",
+    lineHeight: "64px",
+    letterSpacing: "-0.25px",
   },
   displayMedium: {
-    fontSize: "45pt",
+    fontSize: "45px",
     fontWeight: 700,
-    lineHeight: "52pt",
-    letterSpacing: "0pt",
+    lineHeight: "52px",
+    letterSpacing: "0px",
   },
   displaySmall: {
-    fontSize: "36pt",
+    fontSize: "36px",
     fontWeight: 700,
-    lineHeight: "44pt",
-    letterSpacing: "0pt",
+    lineHeight: "44px",
+    letterSpacing: "0px",
   },
   headlineLarge: {
-    fontSize: "32pt",
+    fontSize: "32px",
     fontWeight: 600,
-    lineHeight: "40pt",
-    letterSpacing: "0pt",
+    lineHeight: "40px",
+    letterSpacing: "0px",
   },
   headlineMedium: {
-    fontSize: "28pt",
+    fontSize: "28px",
     fontWeight: 600,
-    lineHeight: "36pt",
-    letterSpacing: "0pt",
+    lineHeight: "36px",
+    letterSpacing: "0px",
   },
   headlineSmall: {
-    fontSize: "24pt",
+    fontSize: "24px",
     fontWeight: 600,
-    lineHeight: "32pt",
-    letterSpacing: "0pt",
+    lineHeight: "32px",
+    letterSpacing: "0px",
   },
   titleLarge: {
-    fontSize: "22pt",
+    fontSize: "22px",
     fontWeight: 600,
-    lineHeight: "28pt",
-    letterSpacing: "0pt",
+    lineHeight: "28px",
+    letterSpacing: "0px",
   },
   titleMedium: {
-    fontSize: "16pt",
+    fontSize: "16px",
     fontWeight: 600,
-    lineHeight: "24pt",
-    letterSpacing: "+0.15pt",
+    lineHeight: "24px",
+    letterSpacing: "+0.15px",
   },
   titleSmall: {
-    fontSize: "24pt",
+    fontSize: "24px",
     fontWeight: 600,
-    lineHeight: "20pt",
-    letterSpacing: "+0.1pt",
+    lineHeight: "20px",
+    letterSpacing: "+0.1px",
   },
   labelLarge: {
-    fontSize: "14pt",
+    fontSize: "14px",
     fontWeight: 300,
-    lineHeight: "20pt",
-    letterSpacing: "+0.1pt",
+    lineHeight: "20px",
+    letterSpacing: "+0.1px",
     textTransform: "uppercase",
   },
   labelMedium: {
-    fontSize: "12pt",
+    fontSize: "12px",
     fontWeight: 300,
-    lineHeight: "16pt",
-    letterSpacing: "+0.5pt",
+    lineHeight: "16px",
+    letterSpacing: "+0.5px",
     textTransform: "uppercase",
   },
   labelSmall: {
-    fontSize: "11pt",
+    fontSize: "11px",
     fontWeight: 300,
-    lineHeight: "16pt",
-    letterSpacing: "+0.5pt",
+    lineHeight: "16px",
+    letterSpacing: "+0.5px",
     textTransform: "uppercase",
   },
   bodyLarge: {
-    fontSize: "16pt",
+    fontSize: "16px",
     fontWeight: 400,
-    lineHeight: "24pt",
-    letterSpacing: "+0.5pt",
+    lineHeight: "24px",
+    letterSpacing: "+0.5px",
   },
   bodyMedium: {
-    fontSize: "14pt",
+    fontSize: "14px",
     fontWeight: 400,
-    lineHeight: "20pt",
-    letterSpacing: "+0.25pt",
+    lineHeight: "20px",
+    letterSpacing: "+0.25px",
   },
   bodySmall: {
-    fontSize: "12pt",
+    fontSize: "12px",
     fontWeight: 400,
-    lineHeight: "16pt",
-    letterSpacing: "+0.4pt",
+    lineHeight: "16px",
+    letterSpacing: "+0.4px",
   },
 };
 

--- a/frontend/src/types/CourseTypes.ts
+++ b/frontend/src/types/CourseTypes.ts
@@ -1,0 +1,5 @@
+export type CourseUnit = {
+  id: string;
+  displayIndex: number;
+  title: string;
+};


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Ticket Name](https://www.notion.so/uwblueprintexecs/10510f3fb1dc808a8073d1dd29cfa7f7?v=fff10f3fb1dc8170be3c000ce6e04a21&p=11110f3fb1dc8025ab37c427ac4f09c0&pm=s)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Added a sidebar to /courses


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1.Check if closing the side bar works (paragraphs should span the whole page)
2. Check if the units are correctly fetched and displayed
3. Check if clicking on a unit makes the text bold and color a bit darker


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Should my drawer be composed inside the SideBar or be a wrapper in the parent
* Is it ok to do display :  open ? "block" : "none", i heard there are some issues with this but not sure what.
* also how tf do i open this sidebar again?


## Checklist
- [ ] My PR name is descriptive and in imperative tense
- [ ] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [ ] I have run the appropriate linter(s)
- [ ] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
