### PR TITLE
Add discriminator for lesson page and activity page

### DIFF
--- a/backend/models/coursemodule.mgmodel.ts
+++ b/backend/models/coursemodule.mgmodel.ts
@@ -25,7 +25,7 @@ export const CourseModuleSchema: Schema = new Schema({
 });
 
 /* eslint-disable no-param-reassign */
-CourseModuleSchema.set("toJSON", {
+CourseModuleSchema.set("toObject", {
   virtuals: true,
   versionKey: false,
   transform: (_doc: Document, ret: Record<string, unknown>) => {

--- a/backend/models/coursepage.mgmodel.ts
+++ b/backend/models/coursepage.mgmodel.ts
@@ -39,23 +39,47 @@ export interface CoursePage extends Document {
   title: string;
   displayIndex: number;
   type: PageType;
+}
+
+export interface LessonPage extends CoursePage {
+  source: string;
+}
+
+export interface ActivityPage extends CoursePage {
   layout: [ElementSkeleton];
 }
 
-export const CoursePageSchema: Schema = new Schema({
-  title: {
+const baseOptions = {
+  discriminatorKey: "type",
+};
+
+export const CoursePageSchema: Schema = new Schema(
+  {
+    title: {
+      type: String,
+      required: true,
+    },
+    displayIndex: {
+      type: Number,
+      required: true,
+    },
+    type: {
+      type: String,
+      required: true,
+      enum: ["Lesson", "Activity"],
+    },
+  },
+  baseOptions,
+);
+
+const LessonPageSchema: Schema = new Schema({
+  source: {
     type: String,
     required: true,
   },
-  displayIndex: {
-    type: Number,
-    required: true,
-  },
-  type: {
-    type: String,
-    required: true,
-    enum: ["Lesson", "Activity"],
-  },
+});
+
+const ActivityPageSchema: Schema = new Schema({
   layout: {
     type: [ElementSkeletonSchema],
     required: true,
@@ -63,7 +87,7 @@ export const CoursePageSchema: Schema = new Schema({
 });
 
 /* eslint-disable no-param-reassign */
-CoursePageSchema.set("toJSON", {
+CoursePageSchema.set("toObject", {
   virtuals: true,
   versionKey: false,
   transform: (_doc: Document, ret: Record<string, unknown>) => {
@@ -72,4 +96,19 @@ CoursePageSchema.set("toJSON", {
   },
 });
 
-export default mongoose.model<CoursePage>("CoursePage", CoursePageSchema);
+const CoursePageModel = mongoose.model<CoursePage>(
+  "CoursePage",
+  CoursePageSchema,
+);
+
+const LessonPageModel = CoursePageModel.discriminator(
+  "Lesson",
+  LessonPageSchema,
+);
+const ActivityPageModel = CoursePageModel.discriminator(
+  "Activity",
+  ActivityPageSchema,
+);
+
+export { LessonPageModel, ActivityPageModel };
+export default CoursePageModel;

--- a/backend/models/courseunit.mgmodel.ts
+++ b/backend/models/courseunit.mgmodel.ts
@@ -25,7 +25,7 @@ const CourseUnitSchema: Schema = new Schema({
 });
 
 /* eslint-disable no-param-reassign */
-CourseUnitSchema.set("toJSON", {
+CourseUnitSchema.set("toObject", {
   virtuals: true,
   versionKey: false,
   transform: (_doc: Document, ret: Record<string, unknown>) => {

--- a/backend/models/helprequest.mgmodel.ts
+++ b/backend/models/helprequest.mgmodel.ts
@@ -52,7 +52,7 @@ const HelpRequestSchema: Schema = new Schema(
 );
 
 /* eslint-disable no-param-reassign */
-HelpRequestSchema.set("toJSON", {
+HelpRequestSchema.set("toObject", {
   virtuals: true,
   versionKey: false,
   transform: (_doc: Document, ret: Record<string, unknown>) => {


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Ticket Name](https://www.notion.so/uwblueprintexecs/Task-Board-db95cd7b93f245f78ee85e3a8a6a316d)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Added discriminators for LessonPage vs. ActivityPage to accommodate PDFs for lessons (see `coursepage.mgmodel.ts`)


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. To test, what I did was import `LessonPageModel` and `ActivityPageModel` into server.ts, write a function that does `[Lesson|Activity]PageModel.create({ <data> })`, and then call this function in the `server.listen` callback. This should create a new document in the `coursepages` model in MongoDB. 


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* 


## Checklist
- [ ] My PR name is descriptive and in imperative tense
- [ ] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [ ] I have run the appropriate linter(s)
- [ ] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
