### PR TITLE
Invite Learner API

### DIFF
--- a/backend/middlewares/validators/authValidators.ts
+++ b/backend/middlewares/validators/authValidators.ts
@@ -44,7 +44,7 @@ export const signupRequestValidator = async (
   return next();
 };
 
-export const inviteAdminRequestValidator = async (
+export const inviteUserRequestValidator = async (
   req: Request,
   res: Response,
   next: NextFunction,

--- a/backend/models/user.mgmodel.ts
+++ b/backend/models/user.mgmodel.ts
@@ -1,6 +1,6 @@
 import mongoose, { Schema, Document, ObjectId } from "mongoose";
 
-import { FacilitatorDTO, Role, Status } from "../types/userTypes";
+import { Role, Status } from "../types/userTypes";
 
 export interface User extends Document {
   id: ObjectId;
@@ -83,12 +83,15 @@ const LearnerSchema = new Schema({
   },
 });
 
-const Administrator = UserModel.discriminator(
+const AdministratorModel = UserModel.discriminator(
   "Administrator",
   AdministratorSchema,
 );
-const FacilitatorModel = UserModel.discriminator<Facilitator>("Facilitator", FacilitatorSchema);
+const FacilitatorModel = UserModel.discriminator<Facilitator>(
+  "Facilitator",
+  FacilitatorSchema,
+);
 const LearnerModel = UserModel.discriminator<Learner>("Learner", LearnerSchema);
 
-export { Administrator, FacilitatorModel, LearnerModel };
+export { AdministratorModel, FacilitatorModel, LearnerModel };
 export default UserModel;

--- a/backend/models/user.mgmodel.ts
+++ b/backend/models/user.mgmodel.ts
@@ -1,6 +1,6 @@
 import mongoose, { Schema, Document, ObjectId } from "mongoose";
 
-import { Role, Status } from "../types/userTypes";
+import { FacilitatorDTO, Role, Status } from "../types/userTypes";
 
 export interface User extends Document {
   id: ObjectId;
@@ -9,6 +9,14 @@ export interface User extends Document {
   authId: string;
   role: Role;
   status: Status;
+}
+
+export interface Learner extends User {
+  facilitator: ObjectId;
+}
+
+export interface Facilitator extends User {
+  learners: Array<ObjectId>;
 }
 
 const baseOptions = {
@@ -79,8 +87,8 @@ const Administrator = UserModel.discriminator(
   "Administrator",
   AdministratorSchema,
 );
-const Facilitator = UserModel.discriminator("Facilitator", FacilitatorSchema);
-const Learner = UserModel.discriminator("Learner", LearnerSchema);
+const FacilitatorModel = UserModel.discriminator<Facilitator>("Facilitator", FacilitatorSchema);
+const LearnerModel = UserModel.discriminator<Learner>("Learner", LearnerSchema);
 
-export { Administrator, Facilitator, Learner };
+export { Administrator, FacilitatorModel, LearnerModel };
 export default UserModel;

--- a/backend/rest/authRoutes.ts
+++ b/backend/rest/authRoutes.ts
@@ -215,7 +215,7 @@ authRouter.post(
         password: temporaryPassword,
         status: "Invited",
         
-      }, req.body.facilitatorId);
+      }, req.body.facilitatorId );
       await authService.sendLearnerInvite(
         req.body.firstName,
         req.body.email,

--- a/backend/rest/authRoutes.ts
+++ b/backend/rest/authRoutes.ts
@@ -212,7 +212,6 @@ authRouter.post(
         length: 20,
         numbers: true,
       });
-      
       const invitedLearnerUser = await userService.createLearner({
         firstName: req.body.firstName,
         lastName: req.body.lastName,
@@ -220,8 +219,7 @@ authRouter.post(
         role: "Learner",
         password: temporaryPassword,
         status: "Invited",
-        
-      }, req.body.facilitatorId );
+      }, ""); // TODO: pass in facilitator Object ID in here
       await authService.sendLearnerInvite(
         req.body.firstName,
         req.body.email,

--- a/backend/rest/authRoutes.ts
+++ b/backend/rest/authRoutes.ts
@@ -207,7 +207,7 @@ authRouter.post(
       const accessToken = getAccessToken(req)!;
       const decodedIdToken: firebaseAdmin.auth.DecodedIdToken =
         await firebaseAdmin.auth().verifyIdToken(accessToken, true);
-      //const { id } = await userService.getUserById(decodedIdToken.uid);
+      const { id } = await userService.getUserById(decodedIdToken.uid);
       const temporaryPassword = generate({
         length: 20,
         numbers: true,
@@ -219,7 +219,7 @@ authRouter.post(
         role: "Learner",
         password: temporaryPassword,
         status: "Invited",
-      }, ""); // TODO: pass in facilitator Object ID in here
+      }, id);
       await authService.sendLearnerInvite(
         req.body.firstName,
         req.body.email,

--- a/backend/rest/authRoutes.ts
+++ b/backend/rest/authRoutes.ts
@@ -207,14 +207,15 @@ authRouter.post(
         length: 20,
         numbers: true,
       });
-      const invitedLearnerUser = await userService.createUser({
+      const invitedLearnerUser = await userService.createLearner({
         firstName: req.body.firstName,
         lastName: req.body.lastName,
         email: req.body.email,
         role: "Learner",
         password: temporaryPassword,
         status: "Invited",
-      });
+        
+      }, req.body.facilitatorId);
       await authService.sendLearnerInvite(
         req.body.firstName,
         req.body.email,

--- a/backend/rest/authRoutes.ts
+++ b/backend/rest/authRoutes.ts
@@ -15,7 +15,6 @@ import {
   updateTemporaryPasswordRequestValidator,
   updateUserStatusRequestValidator,
 } from "../middlewares/validators/authValidators";
-import * as firebaseAdmin from "firebase-admin"
 import nodemailerConfig from "../nodemailer.config";
 import AuthService from "../services/implementations/authService";
 import EmailService from "../services/implementations/emailService";
@@ -208,24 +207,27 @@ authRouter.post(
         length: 20,
         numbers: true,
       });
-      const invitedLearnerUser = await userService.createLearner({
-        firstName: req.body.firstName,
-        lastName: req.body.lastName,
-        email: req.body.email,
-        role: "Learner",
-        password: temporaryPassword,
-        status: "Invited",
-      }, id);
+      const invitedLearnerUser = await userService.createLearner(
+        {
+          firstName: req.body.firstName,
+          lastName: req.body.lastName,
+          email: req.body.email,
+          role: "Learner",
+          password: temporaryPassword,
+          status: "Invited",
+        },
+        req.body.facilitatorId,
+      );
       await authService.sendLearnerInvite(
         req.body.firstName,
         req.body.email,
-        temporaryPassword
+        temporaryPassword,
       );
       res.status(200).json(invitedLearnerUser);
     } catch (error: unknown) {
       res.status(500).json({ error: getErrorMessage(error) });
     }
-  }
+  },
 );
 
 // /* Reset password through a "Forgot Password" option */

--- a/backend/rest/authRoutes.ts
+++ b/backend/rest/authRoutes.ts
@@ -207,7 +207,7 @@ authRouter.post(
       const accessToken = getAccessToken(req)!;
       const decodedIdToken: firebaseAdmin.auth.DecodedIdToken =
         await firebaseAdmin.auth().verifyIdToken(accessToken, true);
-      const { id } = await userService.getUserById(decodedIdToken.uid);
+      //const { id } = await userService.getUserById(decodedIdToken.uid);
       const temporaryPassword = generate({
         length: 20,
         numbers: true,

--- a/backend/rest/authRoutes.ts
+++ b/backend/rest/authRoutes.ts
@@ -204,10 +204,6 @@ authRouter.post(
   isAuthorizedByRole(new Set(["Facilitator"])),
   async (req, res) => {
     try {
-      const accessToken = getAccessToken(req)!;
-      const decodedIdToken: firebaseAdmin.auth.DecodedIdToken =
-        await firebaseAdmin.auth().verifyIdToken(accessToken, true);
-      const { id } = await userService.getUserById(decodedIdToken.uid);
       const temporaryPassword = generate({
         length: 20,
         numbers: true,

--- a/backend/rest/authRoutes.ts
+++ b/backend/rest/authRoutes.ts
@@ -15,6 +15,7 @@ import {
   updateTemporaryPasswordRequestValidator,
   updateUserStatusRequestValidator,
 } from "../middlewares/validators/authValidators";
+import * as firebaseAdmin from "firebase-admin"
 import nodemailerConfig from "../nodemailer.config";
 import AuthService from "../services/implementations/authService";
 import EmailService from "../services/implementations/emailService";
@@ -203,10 +204,15 @@ authRouter.post(
   isAuthorizedByRole(new Set(["Facilitator"])),
   async (req, res) => {
     try {
+      const accessToken = getAccessToken(req)!;
+      const decodedIdToken: firebaseAdmin.auth.DecodedIdToken =
+        await firebaseAdmin.auth().verifyIdToken(accessToken, true);
+      const { id } = await userService.getUserById(decodedIdToken.uid);
       const temporaryPassword = generate({
         length: 20,
         numbers: true,
       });
+      
       const invitedLearnerUser = await userService.createLearner({
         firstName: req.body.firstName,
         lastName: req.body.lastName,

--- a/backend/services/implementations/authService.ts
+++ b/backend/services/implementations/authService.ts
@@ -181,6 +181,45 @@ class AuthService implements IAuthService {
     }
   }
 
+  async sendLearnerInvite(
+    firstName: string,
+    email: string,
+    temporaryPassword: string,
+  ): Promise<void> {
+    if (!this.emailService) {
+      const errorMessage =
+        "Attempted to call sendLearnerInvite but this instance of AuthService does not have an EmailService instance";
+      Logger.error(errorMessage);
+      throw new Error(errorMessage);
+    }
+
+    const emailVerificationLink = await firebaseAdmin
+      .auth()
+      .generateEmailVerificationLink(email);
+
+    const emailBody = `Hello ${firstName},
+      <br><br>
+      Welcome to Smart Saving, Smart Spending!
+      <br><br>
+      Please click the link to confirm your account: <a href=${emailVerificationLink}>Confirm my account</a>
+      <br>
+      If the link has expired, ask your facilitator to invite you again.
+      <br><br>
+      To log in for the first time, use the following email and password:
+      <br><br>
+      Email: <strong>${email}</strong>
+      <br>
+      Password: <strong>${temporaryPassword}</strong>
+      <br><br>
+      Happy learning!`;
+
+    await this.emailService.sendEmail(
+      email,
+      "Welcome to Smart Saving, Smart Spending!",
+      emailBody,
+    );
+  }
+
   async isAuthorizedByRole(
     accessToken: string,
     roles: Set<Role>,

--- a/backend/services/implementations/userService.ts
+++ b/backend/services/implementations/userService.ts
@@ -2,7 +2,7 @@ import * as firebaseAdmin from "firebase-admin";
 
 import { ObjectId } from "mongoose";
 import IUserService from "../interfaces/userService";
-import MgUser, { User } from "../../models/user.mgmodel";
+import MgUser, { Facilitator, Learner, User } from "../../models/user.mgmodel";
 import {
   CreateUserDTO,
   Role,
@@ -187,6 +187,11 @@ class UserService implements IUserService {
   async createLearner(user: CreateUserDTO, facilitatorId: string): Promise<UserDTO> {
     this.createUser(user);
     // TODO: this.updateUserById()
+    let firebaseUser: firebaseAdmin.auth.UserRecord;
+    const newLearner = await Learner.create({
+      ...user, Facilitator: facilitatorId
+    });
+
     return {} as UserDTO;
   }
 

--- a/backend/services/implementations/userService.ts
+++ b/backend/services/implementations/userService.ts
@@ -2,10 +2,9 @@ import * as firebaseAdmin from "firebase-admin";
 
 import { ObjectId } from "mongoose";
 import IUserService from "../interfaces/userService";
-import MgUser, { Facilitator, Learner, User, LearnerModel, FacilitatorModel } from "../../models/user.mgmodel";
+import MgUser, { User } from "../../models/user.mgmodel";
 import {
   CreateUserDTO,
-  LearnerDTO,
   Role,
   Status,
   UpdateUserDTO,
@@ -185,44 +184,13 @@ class UserService implements IUserService {
     };
   }
 
-  async createLearner(user: CreateUserDTO, facilitatorId: string): Promise<LearnerDTO> {
-        // TODO: this.updateUserById()
-    let newLearner: Learner;
-    let firebaseUser: firebaseAdmin.auth.UserRecord;
-    try {
-      firebaseUser = await firebaseAdmin.auth().createUser({
-        email: user.email,
-        password: user.password,
-      });
-      try {
-        newLearner = await LearnerModel.create({
-          ...user,
-          facilitator: facilitatorId
-        });
-      } catch(mongoError) {
-        try {
-          await firebaseAdmin.auth().deleteUser(firebaseUser.uid);
-        } catch (firebaseError: unknown) {
-          const errorMessage = [
-            "Failed to rollback Firebase user creation after MongoDB user creation failure. Reason =",
-            getErrorMessage(firebaseError),
-            "Orphaned authId (Firebase uid) =",
-            firebaseUser.uid,
-          ];
-          Logger.error(errorMessage.join(" "));
-        }
-        throw mongoError
-      }
-    } catch(err: unknown) {
-      Logger.error(`Failed to create user. Reason = ${getErrorMessage(err)}`);
-      throw err;
-    }
-    
-
-    return {
-      ...newLearner.toObject(), 
-      email: firebaseUser.email?? ""
-    };
+  async createLearner(
+    user: CreateUserDTO,
+    facilitatorId: string,
+  ): Promise<UserDTO> {
+    this.createUser(user);
+    // TODO: this.updateUserById()
+    return {} as UserDTO;
   }
 
   async updateUserById(

--- a/backend/services/implementations/userService.ts
+++ b/backend/services/implementations/userService.ts
@@ -187,10 +187,20 @@ class UserService implements IUserService {
   async createLearner(
     user: CreateUserDTO,
     facilitatorId: string,
-  ): Promise<UserDTO> {
-    this.createUser(user);
-    // TODO: this.updateUserById()
-    return {} as UserDTO;
+  ): Promise<LearnerDTO> {
+    let firebaseUser: firebaseAdmin.auth.UserRecord;
+    const newLearner = await Learner.create({
+      ...user,
+      facilitator: facilitatorId,
+    });
+
+    await Facilitator.findByIdAndUpdate(
+      facilitatorId,
+      { $push: { learners: newLearner.id } },
+      { runValidators: true },
+    );
+
+    return {} as LearnerDTO;
   }
 
   async updateUserById(

--- a/backend/services/implementations/userService.ts
+++ b/backend/services/implementations/userService.ts
@@ -1,5 +1,6 @@
 import * as firebaseAdmin from "firebase-admin";
-import mongoose, { mongo, ObjectId } from "mongoose";
+
+import mongoose, { ObjectId } from "mongoose";
 import IUserService from "../interfaces/userService";
 import MgUser, { User } from "../../models/user.mgmodel";
 import {
@@ -183,10 +184,7 @@ class UserService implements IUserService {
     };
   }
 
-  async createLearner(
-    user: CreateUserDTO,
-    facilitatorId: string,
-  ): Promise<LearnerDTO> {
+  async createLearner(user: CreateUserDTO, facilitatorId: string): Promise<LearnerDTO> {
     let newLearner: Learner;
     let firebaseUser: firebaseAdmin.auth.UserRecord;
     try {
@@ -198,7 +196,6 @@ class UserService implements IUserService {
         newLearner = await LearnerModel.create({
           ...user,
           facilitator: facilitatorId,
-          authId: firebaseUser.uid,
         });
         await FacilitatorModel.findByIdAndUpdate(
           facilitatorId,
@@ -224,18 +221,10 @@ class UserService implements IUserService {
       throw err;
     }
 
-    await Facilitator.findByIdAndUpdate(
-      facilitatorId,
-      { $push: { learners: newLearner.id } },
-      { runValidators: true },
-    );
-
     return {
       ...newLearner.toObject(),
       email: firebaseUser.email ?? "",
     }
-    
-
   }
 
   async updateUserById(

--- a/backend/services/implementations/userService.ts
+++ b/backend/services/implementations/userService.ts
@@ -11,6 +11,7 @@ import {
   CreateUserDTO,
   LearnerDTO,
   Role,
+  Status,
   UpdateUserDTO,
   UserDTO,
 } from "../../types/userTypes";

--- a/backend/services/implementations/userService.ts
+++ b/backend/services/implementations/userService.ts
@@ -184,6 +184,12 @@ class UserService implements IUserService {
     };
   }
 
+  async createLearner(user: CreateUserDTO, facilitatorId: string): Promise<UserDTO> {
+    this.createUser(user);
+    // TODO: this.updateUserById()
+    return {} as UserDTO;
+  }
+
   async updateUserById(
     userId: ObjectId | string,
     user: UpdateUserDTO,

--- a/backend/services/interfaces/authService.ts
+++ b/backend/services/interfaces/authService.ts
@@ -53,6 +53,18 @@ interface IAuthService {
   sendAdminInvite(email: string, temporaryPassword: string): Promise<void>;
 
   /**
+   * Sends an email invitation to an invited learner with the temporary password specified
+   * @param email email of new learner invited
+   * @param temporaryPassword the new learner's temporary password
+   * @throws Error if unable to generate link or send email
+   */
+  sendLearnerInvite(
+    firstName: string,
+    email: string,
+    temporaryPassword: string,
+  ): Promise<void>;
+
+  /**
    * Changes a user's password
    * @param email the user's email address
    * @param newPassword new password chosen to replace the user's old password

--- a/backend/services/interfaces/userService.ts
+++ b/backend/services/interfaces/userService.ts
@@ -74,8 +74,6 @@ interface IUserService {
    */
   createLearner(user: CreateUserDTO, facilitatorId: string): Promise<UserDTO>;
 
-  // TODO: add addLearner
-
   /**
    * Update a user.
    * Note: the password cannot be updated using this method, use IAuthService.resetPassword instead

--- a/backend/services/interfaces/userService.ts
+++ b/backend/services/interfaces/userService.ts
@@ -66,6 +66,17 @@ interface IUserService {
   createUser(user: CreateUserDTO, authId?: string): Promise<UserDTO>;
 
   /**
+   * Create a learner, link them to their facilitator, and add them to their facilitator's learner list
+   * @param user the user to be created
+   * @param facilitatorId the auth ID of the facilitator to link the new learner to
+   * @returns a UserDTO with the created learner's information
+   * @throws Error if user creation fails
+   */
+  createLearner(user: CreateUserDTO, facilitatorId: string): Promise<UserDTO>;
+
+  // TODO: add addLearner
+
+  /**
    * Update a user.
    * Note: the password cannot be updated using this method, use IAuthService.resetPassword instead
    * @param userId user's id

--- a/frontend/src/theme/theme.ts
+++ b/frontend/src/theme/theme.ts
@@ -8,7 +8,6 @@ import { TypographyStyleOptions } from "@mui/material/styles/createTypography";
 import { error, learner, administrator, facilitator, neutral } from "./palette";
 import "@fontsource/lexend-deca";
 
-
 // adding custom attributes to palette
 declare module "@mui/material/styles" {
   // allow configuration using `createTheme`


### PR DESCRIPTION
[Invite Learner](https://www.notion.so/uwblueprintexecs/Invite-Learner-9a3785effc344d4ab763f322b50c420d?pvs=4)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
- A new Learner Schema was created which just extends the User Schema but has an additional facilitator parameter (since each learner is linked to a facilitator)
- When the facilitator creates the learner, a post request is sent with learner details, then the learner is added to the database and a verification email is sent to the learner. 
-  new function `createLearner `is added to in `userService `which adds the user to firebase and `mongoDB`
- new function `sendLearnerInvite `is added in `authService `which sends verification email to learner


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Log in as a facilitator to get your auth token
2. Go to postman and create a POST request:
![2](https://github.com/user-attachments/assets/6248a3f9-ecca-4743-b513-686ded7d3894)
make sure you paste your auth token
3. Go to MongoDBCompass and you should see an array of learners associated your facilitator id
![2](https://github.com/user-attachments/assets/e33d3570-c3fe-4f74-af65-eca3690aa146)

4.There should be a verification email sent to the learner you invited
![3](https://github.com/user-attachments/assets/da73b3f9-8d57-4cb8-89a9-fa2ab5db8b92)



<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* The facilitator id was initially fetched from firebase, however that led to mongoDB object errors so to get around this, the facilitator id is received from the body of the post request. Is this okay in terms of good code design? (After, Before)
![5](https://github.com/user-attachments/assets/93cc562b-9627-4d9d-bee4-30c4e0895385)


It’s cut off in the screenshot but the second parameter of `createLearner` was initially `id`

## Checklist
- [ ] My PR name is descriptive and in imperative tense
- [ ] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [ ] I have run the appropriate linter(s)
- [ ] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR

