### PR TITLE
upload profile pictures

### DIFF
--- a/backend/middlewares/validators/userValidators.ts
+++ b/backend/middlewares/validators/userValidators.ts
@@ -1,5 +1,40 @@
 import { Request, Response, NextFunction } from "express";
-import { getApiValidationError, validatePrimitive } from "./util";
+import {
+  getApiValidationError,
+  validatePrimitive,
+  validateFileType,
+  getFileTypeValidationError,
+} from "./util";
+
+export const uploadProfilePictureValidator = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) => {
+  if (!validatePrimitive(req.params.userId, "string")) {
+    return res.status(400).send(getApiValidationError("userId", "string"));
+  }
+
+  if (!req.file) {
+    return res.status(400).send("File has not been uploaded");
+  }
+
+  if (!req.file.buffer) {
+    return res.status(400).send("File missing buffer field");
+  }
+
+  if (!req.file.mimetype) {
+    return res.status(400).send("File is missing mimetype field");
+  }
+
+  if (!validateFileType(req.file.mimetype)) {
+    return res
+      .status(400)
+      .send(getFileTypeValidationError(req.body.file.mimetype));
+  }
+
+  return next();
+};
 
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 export const createUserDtoValidator = async (

--- a/backend/models/user.mgmodel.ts
+++ b/backend/models/user.mgmodel.ts
@@ -10,6 +10,7 @@ export interface User extends Document {
   role: Role;
   status: Status;
   email: string;
+  profilePicture?: string;
 }
 
 export interface Learner extends User {
@@ -52,6 +53,9 @@ export const UserSchema: Schema = new Schema(
     email: {
       type: String,
       required: true,
+    },
+    profilePicture: {
+      type: String,
     },
   },
   baseOptions,

--- a/backend/services/implementations/fileStorageService.ts
+++ b/backend/services/implementations/fileStorageService.ts
@@ -14,12 +14,8 @@ class FileStorageService implements IFileStorageService {
     this.bucketName = bucketName;
   }
 
-  async getFile(fileName: string, expirationTimeMinutes = 60): Promise<string> {
+  async getFile(fileName: string): Promise<string> {
     const bucket = storage().bucket(this.bucketName);
-    const expirationDate = new Date();
-    expirationDate.setMinutes(
-      expirationDate.getMinutes() + expirationTimeMinutes,
-    );
     try {
       const currentBlob = await bucket.file(fileName);
       if (!(await currentBlob.exists())[0]) {
@@ -103,7 +99,7 @@ class FileStorageService implements IFileStorageService {
           metadata: { contentType },
         });
       }
-      return await this.getFile(fileName, 5.26e7);
+      return await this.getFile(fileName);
     } catch (error: unknown) {
       Logger.error(`Failed to upload file. Reason = ${getErrorMessage(error)}`);
       throw error;

--- a/backend/services/implementations/userService.ts
+++ b/backend/services/implementations/userService.ts
@@ -210,17 +210,9 @@ class UserService implements IUserService {
 
     try {
       // must explicitly specify runValidators when updating through findByIdAndUpdate
-      oldUser = await MgUser.findByIdAndUpdate(
-        userId,
-        {
-          firstName: user.firstName,
-          lastName: user.lastName,
-          role: user.role,
-          status: user.status,
-          email: user.email,
-        },
-        { runValidators: true },
-      );
+      oldUser = await MgUser.findByIdAndUpdate(userId, user, {
+        runValidators: true,
+      });
 
       if (!oldUser) {
         throw new Error(`userId ${userId} not found.`);

--- a/backend/types/userTypes.ts
+++ b/backend/types/userTypes.ts
@@ -15,6 +15,7 @@ export type UserDTO = {
   email: string;
   role: Role;
   status: Status;
+  profilePicture?: string;
 };
 
 export type CreateUserDTO = Omit<UserDTO, "id"> & { password: string };


### PR DESCRIPTION
## Notion ticket link
[Upload Profile Picture](https://www.notion.so/uwblueprintexecs/Upload-Profile-Picture-19610f3fb1dc80faa307f498949c7ccc?pvs=4)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Updated user schema to include an optional profilePicture string field
* Created a post route to upload profile picture to firebase


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Install multer
2. Test the following post route users/:userId/uploadProfilePicture, use a different userId than the one in the example below
3. In the request add an `uploadedImage` file field and upload a png, jpeg, or webp image
4. Make sure you add your auth token!!! All 3 learner types should have access. 
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/03675c94-527c-4546-9dc2-fcee96615f06" />

5. You should see your picture in user/profilePicture directory in firebase
6. In MongoDB, there should be a profilePicture field with the ImageURL, check that the URL leads to the uploaded image



## Checklist
- [ ] My PR name is descriptive and in imperative tense
- [ ] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [ ] I have run the appropriate linter(s)
- [ ] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
