### PR TITLE
Integrate Module Activities into Module Viewing Sidebar

### DIFF
--- a/backend/middlewares/validators/courseValidators.ts
+++ b/backend/middlewares/validators/courseValidators.ts
@@ -139,7 +139,7 @@ export const pageBelongsToModuleValidator = async (
 
   const courseModule = await courseModuleService.getCourseModule(moduleId);
 
-  if (!courseModule?.pages.includes(pageId)) {
+  if (courseModule?.pages.filter((page) => page.id === pageId).length === 0) {
     return res
       .status(404)
       .send(

--- a/backend/models/coursemodule.mgmodel.ts
+++ b/backend/models/coursemodule.mgmodel.ts
@@ -1,4 +1,5 @@
 import mongoose, { Document, ObjectId, Schema } from "mongoose";
+import mongooseLeanId from "mongoose-lean-id";
 
 export interface CourseModule extends Document {
   id: string;
@@ -27,6 +28,8 @@ export const CourseModuleSchema: Schema = new Schema({
     type: String,
   },
 });
+
+CourseModuleSchema.plugin(mongooseLeanId);
 
 /* eslint-disable no-param-reassign */
 CourseModuleSchema.set("toObject", {

--- a/backend/models/coursepage.mgmodel.ts
+++ b/backend/models/coursepage.mgmodel.ts
@@ -1,5 +1,6 @@
-import mongoose, { Schema, Document } from "mongoose";
 import { ObjectId } from "mongodb";
+import mongoose, { Document, Schema } from "mongoose";
+import mongooseLeanId from "mongoose-lean-id";
 import { ElementSkeleton, PageType } from "../types/courseTypes";
 
 const ElementSkeletonSchema: Schema = new Schema({
@@ -88,6 +89,8 @@ CoursePageSchema.set("toObject", {
   },
 });
 
+CoursePageSchema.plugin(mongooseLeanId);
+
 const CoursePageModel = mongoose.model<CoursePage>(
   "CoursePage",
   CoursePageSchema,
@@ -102,5 +105,5 @@ const ActivityPageModel = CoursePageModel.discriminator(
   ActivityPageSchema,
 );
 
-export { LessonPageModel, ActivityPageModel };
+export { ActivityPageModel, LessonPageModel };
 export default CoursePageModel;

--- a/backend/package.json
+++ b/backend/package.json
@@ -16,6 +16,7 @@
   "license": "ISC",
   "dependencies": {
     "@types/json2csv": "^5.0.3",
+    "@types/mongoose-lean-id": "^1.0.0",
     "@types/multer": "^1.4.6",
     "@types/swagger-ui-express": "^4.1.2",
     "@types/uuid": "^8.3.1",
@@ -31,6 +32,7 @@
     "lodash": "^4.17.21",
     "mongodb": "^6.6.2",
     "mongoose": "^8.4.0",
+    "mongoose-lean-id": "^1.0.0",
     "multer": "^1.4.5-lts.1",
     "node-fetch": "^2.6.1",
     "nodemailer": "^6.9.9",

--- a/backend/services/implementations/courseModuleService.ts
+++ b/backend/services/implementations/courseModuleService.ts
@@ -1,11 +1,13 @@
 /* eslint-disable class-methods-use-this */
 import fs from "fs/promises";
-import { startSession } from "mongoose";
+import { Schema, startSession } from "mongoose";
 import { PDFDocument } from "pdf-lib";
 import MgCourseModule, {
   CourseModule,
 } from "../../models/coursemodule.mgmodel";
-import { LessonPageModel } from "../../models/coursepage.mgmodel";
+import CoursePageModel, {
+  LessonPageModel,
+} from "../../models/coursepage.mgmodel";
 import MgCourseUnit, { CourseUnit } from "../../models/courseunit.mgmodel";
 import {
   CourseModuleDTO,
@@ -66,17 +68,27 @@ class CourseModuleService implements ICourseModuleService {
     try {
       const courseModule: CourseModule | null = await MgCourseModule.findById(
         courseModuleId,
-      );
+      )
+        .lean()
+        .exec();
       if (!courseModule) {
         throw new Error(`Course module with id ${courseModuleId} not found.`);
       }
       const lessonPdfUrl: string | undefined = await fileStorageService.getFile(
         `course/pdfs/module-${courseModuleId}.pdf`,
       );
+      const fetchPage = async (page: Schema.Types.ObjectId) => {
+        const pageObject = await CoursePageModel.findById(page).lean().exec();
+        if (!pageObject) {
+          throw new Error(`Page with id ${page} not found.`);
+        }
+        return pageObject;
+      };
+      const pageObjects = Promise.all(courseModule.pages.map(fetchPage));
       return {
         ...courseModule,
         lessonPdfUrl,
-        pages: courseModule.pages.map((page) => page.toString()),
+        pages: await pageObjects,
       };
     } catch (error) {
       Logger.error(

--- a/backend/types/courseTypes.ts
+++ b/backend/types/courseTypes.ts
@@ -13,7 +13,7 @@ export type CourseModuleDTO = {
   displayIndex: number;
   title: string;
   imageURL?: string;
-  pages: string[];
+  pages: CoursePageDTO[];
   lessonPdfUrl?: string;
 };
 

--- a/backend/yarn.lock
+++ b/backend/yarn.lock
@@ -2026,6 +2026,14 @@
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-5.1.2.tgz#07508b45797cb81ec3f273011b054cd0755eddca"
   integrity sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==
 
+"@types/mongoose-lean-id@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@types/mongoose-lean-id/-/mongoose-lean-id-1.0.0.tgz#1ded4d83f9fc55b5e600b6ec2dcf6344d049e915"
+  integrity sha512-HPlgsJjxGxvE8en6pAc3fy9ItI8biqSDgBHCsoOPpC2s6ewe45rk4KNY5vfRti9eGqa0GhdirR7mqMGPRQLLhg==
+  dependencies:
+    "@types/node" "*"
+    mongoose "7.x || 8.x"
+
 "@types/mongoose@^5.11.97":
   version "5.11.97"
   resolved "https://registry.yarnpkg.com/@types/mongoose/-/mongoose-5.11.97.tgz#80b0357f3de6807eb597262f52e49c3e13ee14d8"
@@ -2825,6 +2833,11 @@ bson@^6.10.1:
   version "6.10.1"
   resolved "https://registry.yarnpkg.com/bson/-/bson-6.10.1.tgz#dcd04703178f5ecf5b25de04edd2a95ec79385d3"
   integrity sha512-P92xmHDQjSKPLHqFxefqMxASNq/aWJMEZugpCjf+AF/pgcUpMMQCg7t7+ewko0/u8AapvF3luf/FoehddEK+sA==
+
+bson@^6.10.3:
+  version "6.10.3"
+  resolved "https://registry.yarnpkg.com/bson/-/bson-6.10.3.tgz#5f9a463af6b83e264bedd08b236d1356a30eda47"
+  integrity sha512-MTxGsqgYTwfshYWTRdmZRC+M7FnG1b4y7RO7p2k3X24Wq0yv1m77Wsj0BzlPzd/IowgESfsruQCUToa7vbOpPQ==
 
 buffer-crc32@~0.2.3:
   version "0.2.13"
@@ -5826,6 +5839,20 @@ mongodb@^6.6.2, mongodb@~6.12.0:
     bson "^6.10.1"
     mongodb-connection-string-url "^3.0.0"
 
+mongodb@~6.13.0:
+  version "6.13.1"
+  resolved "https://registry.yarnpkg.com/mongodb/-/mongodb-6.13.1.tgz#924319f957a22efda45a96d38c08a594fd7929fa"
+  integrity sha512-gdq40tX8StmhP6akMp1pPoEVv+9jTYFSrga/g23JxajPAQhH39ysZrHGzQCSd9PEOnuEQEdjIWqxO7ZSwC0w7Q==
+  dependencies:
+    "@mongodb-js/saslprep" "^1.1.9"
+    bson "^6.10.3"
+    mongodb-connection-string-url "^3.0.0"
+
+mongoose-lean-id@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/mongoose-lean-id/-/mongoose-lean-id-1.0.0.tgz#31fb5b019522bd03be9b80a394946e99520456a7"
+  integrity sha512-FmDnEbEwSjuK02E/KVrXTM44/Cht3O1r5yqE1fdRbbHkTJjt29WAjNqdn3eJ7sfCFaxPak3S9tHEaTuJroof3w==
+
 mongoose@*, mongoose@^8.4.0:
   version "8.9.5"
   resolved "https://registry.yarnpkg.com/mongoose/-/mongoose-8.9.5.tgz#90a2d70b48a66022a61d7a170ab4fad106b83cba"
@@ -5834,6 +5861,19 @@ mongoose@*, mongoose@^8.4.0:
     bson "^6.10.1"
     kareem "2.6.3"
     mongodb "~6.12.0"
+    mpath "0.9.0"
+    mquery "5.0.0"
+    ms "2.1.3"
+    sift "17.1.3"
+
+"mongoose@7.x || 8.x":
+  version "8.11.0"
+  resolved "https://registry.yarnpkg.com/mongoose/-/mongoose-8.11.0.tgz#11e7f604f1febc4c11f56ec240dc740352aace7e"
+  integrity sha512-xaQSuaLk2JKmXI5zDVVWXVCQTnWhAe8MFOijMnwOuP/wucKVphd3f+ouDKivCDMGjYBDrR7dtoyV0U093xbKqA==
+  dependencies:
+    bson "^6.10.1"
+    kareem "2.6.3"
+    mongodb "~6.13.0"
     mpath "0.9.0"
     mquery "5.0.0"
     ms "2.1.3"

--- a/frontend/src/components/pages/ViewModulePage.tsx
+++ b/frontend/src/components/pages/ViewModulePage.tsx
@@ -9,7 +9,6 @@ import BookmarkBorderIcon from "@mui/icons-material/BookmarkBorder";
 import FullscreenIcon from "@mui/icons-material/Fullscreen";
 import PlayCircleOutlineIcon from "@mui/icons-material/PlayCircleOutline";
 import { Box, Button, IconButton, Typography } from "@mui/material";
-import type { PDFDocumentProxy } from "pdfjs-dist";
 import { Document, Page, pdfjs, Thumbnail } from "react-pdf";
 import "react-pdf/dist/Page/AnnotationLayer.css";
 import "react-pdf/dist/Page/TextLayer.css";
@@ -39,7 +38,6 @@ const ViewModulePage = () => {
   const requestedModuleId = queryParams.get("moduleId") || "";
   const requestedPageId = queryParams.get("pageId") || "";
 
-  const [numPages, setNumPages] = useState<number>();
   const [currentPage, setCurrentPage] = useState(0);
   const [isFullScreen, setIsFullScreen] = useState(false);
   const [bookMarkedPages, setBookMarkedPages] = useState(new Set<number>());
@@ -54,6 +52,7 @@ const ViewModulePage = () => {
   const [containerWidth, setContainerWidth] = useState<number>(0);
   const currentPageObject = module?.pages[currentPage];
   const thumbnailRefs = useRef<(HTMLDivElement | null)[]>([]);
+  const numPages = module?.pages.length || 0;
 
   const fetchModule = useCallback(async () => {
     const fetchedModule = await CourseAPIClient.getModuleById(
@@ -134,12 +133,6 @@ const ViewModulePage = () => {
     handleResize();
     return () => window.removeEventListener("resize", handleResize);
   }, [handleResize, isFullScreen, pageHeight]);
-
-  const onDocumentLoadSuccess = ({
-    numPages: nextNumPages,
-  }: PDFDocumentProxy): void => {
-    setNumPages(nextNumPages);
-  };
 
   const toggleBookmark = (pageNumber: number) => {
     setBookMarkedPages((prev) => {
@@ -248,11 +241,7 @@ const ViewModulePage = () => {
   );
 
   return (
-    <Document
-      file={module?.lessonPdfUrl || null}
-      onLoadSuccess={onDocumentLoadSuccess}
-      options={options}
-    >
+    <Document file={module?.lessonPdfUrl || null} options={options}>
       <Box display="flex" flexDirection="row">
         {SideBar}
         <Box
@@ -361,7 +350,7 @@ const ViewModulePage = () => {
           >
             <Box display="flex" gap="16px">
               <IconButton
-                disabled={currentPage === 1}
+                disabled={currentPage <= 0}
                 onClick={() => setCurrentPage(currentPage - 1)}
                 sx={{
                   border: "1px solid black",
@@ -379,10 +368,10 @@ const ViewModulePage = () => {
                   fontWeight: "400",
                 }}
               >
-                {padNumber(currentPage)}
+                {padNumber(currentPage + 1)}
               </Typography>
               <IconButton
-                disabled={currentPage === numPages}
+                disabled={currentPage >= numPages - 1}
                 onClick={() => setCurrentPage(currentPage + 1)}
                 sx={{
                   border: "1px solid black",

--- a/frontend/src/components/pages/ViewModulePage.tsx
+++ b/frontend/src/components/pages/ViewModulePage.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/react-in-jsx-scope */
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import ArrowBackIcon from "@mui/icons-material/ArrowBack";
 import ArrowBackIosIcon from "@mui/icons-material/ArrowBackIos";
@@ -14,8 +14,13 @@ import { Document, Page, pdfjs, Thumbnail } from "react-pdf";
 import "react-pdf/dist/Page/AnnotationLayer.css";
 import "react-pdf/dist/Page/TextLayer.css";
 import CourseAPIClient from "../../APIClients/CourseAPIClient";
-import useQuery from "../../hooks/useQuery";
-import { CourseModule } from "../../types/CourseTypes";
+import * as Routes from "../../constants/Routes";
+import useQueryParams from "../../hooks/useQueryParams";
+import {
+  CourseModule,
+  isActivityPage,
+  isLessonPage,
+} from "../../types/CourseTypes";
 import { padNumber } from "../../utils/StringUtils";
 import "./ViewModulePage.css";
 
@@ -30,11 +35,12 @@ const options = {
 };
 
 const ViewModulePage = () => {
-  const searchParams = useQuery();
-  const moduleId = searchParams.get("moduleId") || "";
+  const { queryParams } = useQueryParams();
+  const requestedModuleId = queryParams.get("moduleId") || "";
+  const requestedPageId = queryParams.get("pageId") || "";
 
   const [numPages, setNumPages] = useState<number>();
-  const [currentPage, setCurrentPage] = useState(1);
+  const [currentPage, setCurrentPage] = useState(0);
   const [isFullScreen, setIsFullScreen] = useState(false);
   const [bookMarkedPages, setBookMarkedPages] = useState(new Set<number>());
   const [module, setModule] = useState<
@@ -46,17 +52,54 @@ const ViewModulePage = () => {
   const [containerHeight, setContainerHeight] = useState<number>(0);
   const [pageWidth, setPageWidth] = useState<number>(0);
   const [containerWidth, setContainerWidth] = useState<number>(0);
+  const currentPageObject = module?.pages[currentPage];
+  const thumbnailRefs = useRef<(HTMLDivElement | null)[]>([]);
 
   const fetchModule = useCallback(async () => {
-    const fetchedModule = await CourseAPIClient.getModuleById(moduleId);
+    const fetchedModule = await CourseAPIClient.getModuleById(
+      requestedModuleId,
+    );
     return fetchedModule;
-  }, [moduleId]);
+  }, [requestedModuleId]);
+
+  const currentPageId = module?.pages[currentPage].id;
 
   useEffect(() => {
-    (async () => setModule(await fetchModule()))();
-  }, [fetchModule, moduleId]);
+    if (currentPageId) {
+      window.history.pushState(
+        { moduleId: module?.id, pageId: currentPageId },
+        "",
+        `${Routes.VIEW_PAGE}?${new URLSearchParams({
+          moduleId: requestedModuleId,
+          pageId: currentPageId,
+        }).toString()}`,
+      );
+    }
+  }, [currentPageId, module?.id, requestedModuleId]);
 
-  function getPageScale() {
+  useEffect(() => {
+    (async () => {
+      const currentModule = await fetchModule();
+      setModule(currentModule);
+      const defaultCurrentPage = currentModule?.pages.findIndex((page) => {
+        return page.id === requestedPageId;
+      });
+      if (defaultCurrentPage && defaultCurrentPage !== -1) {
+        setCurrentPage(defaultCurrentPage);
+      }
+    })();
+  }, [fetchModule, requestedPageId]);
+
+  useEffect(() => {
+    if (thumbnailRefs.current[currentPage]) {
+      thumbnailRefs.current[currentPage]?.scrollIntoView({
+        behavior: "smooth",
+        block: "center",
+      });
+    }
+  });
+
+  const getPageScale = () => {
     if (
       pageHeight === 0 ||
       containerHeight === 0 ||
@@ -68,7 +111,7 @@ const ViewModulePage = () => {
     const scaleToHeight = containerHeight / pageHeight;
     const scaleToWidth = containerWidth / pageWidth;
     return Math.min(scaleToHeight, scaleToWidth);
-  }
+  };
 
   const handleResize = useCallback(() => {
     if (pageHeight === 0) {
@@ -112,76 +155,96 @@ const ViewModulePage = () => {
 
   const boxHeight = "calc(100vh - 68px)";
 
-  const SideBar = () => (
-    <Box
-      width="auto"
-      minWidth="fit-content"
-      maxHeight={boxHeight}
-      padding="24px"
-      borderRight="1px solid #ddd"
-      sx={{
-        overflowY: "auto",
-        gapY: "24px",
-      }}
-      className="no-scrollbar"
-    >
-      {Array.from(new Array(numPages), (_, index) => (
-        <Box
-          key={`thumbnail_${index + 1}`}
-          sx={{
-            cursor: "pointer",
-            marginBottom: "10px",
-            borderRadius: "5px",
-            display: "flex",
-            justifyItems: "center",
-            flexDirection: "row",
-            gap: "8px",
-          }}
-          onClick={() => setCurrentPage(index + 1)}
-        >
+  const SideBar = useMemo(
+    () => (
+      <Box
+        width="auto"
+        minWidth="fit-content"
+        maxHeight={boxHeight}
+        padding="24px"
+        borderRight="1px solid #ddd"
+        sx={{
+          overflowY: "auto",
+          gapY: "24px",
+          ...(isFullScreen && { display: "none" }),
+        }}
+        className="no-scrollbar"
+      >
+        {module?.pages.map((page, index) => (
           <Box
-            sx={{
-              color: index + 1 === currentPage ? "#006877" : "black",
+            key={`thumbnail_${index}`}
+            ref={(el: HTMLDivElement | null) => {
+              thumbnailRefs.current[index] = el;
             }}
+            sx={{
+              cursor: "pointer",
+              marginBottom: "10px",
+              borderRadius: "5px",
+              display: "flex",
+              justifyItems: "center",
+              flexDirection: "row",
+              gap: "8px",
+            }}
+            onClick={() => setCurrentPage(index)}
           >
-            <Typography
+            <Box
               sx={{
-                lineHeight: "15px",
-                fontSize: "12.5px",
-                fontWeight: index + 1 === currentPage ? "700" : "300",
+                color: index === currentPage ? "#006877" : "black",
               }}
             >
-              {padNumber(index + 1)}
-            </Typography>
-            {index + 1 === currentPage && (
-              <BookmarkIcon sx={{ fontSize: "16px" }} />
-            )}
-          </Box>
-          <Box
-            sx={{
-              position: "relative",
-              border: currentPage === index + 1 ? "2px solid #006877" : "none",
-              borderRadius: "4px",
-              width: "fit-content",
-            }}
-          >
-            {currentPage === index + 1 && (
-              <PlayCircleOutlineIcon
+              <Typography
                 sx={{
-                  position: "absolute",
-                  top: "50%",
-                  left: "50%",
-                  transform: "translate(-50%, -50%)",
-                  fontSize: "60px",
-                  zIndex: "1",
+                  lineHeight: "15px",
+                  fontSize: "12.5px",
+                  fontWeight: index === currentPage ? "700" : "300",
                 }}
-              />
-            )}
-            <Thumbnail pageNumber={index + 1} height={130} scale={1.66} />
+              >
+                {padNumber(index + 1)}
+              </Typography>
+              {index === currentPage && (
+                <BookmarkIcon sx={{ fontSize: "16px" }} />
+              )}
+            </Box>
+            <Box
+              sx={{
+                position: "relative",
+                border: currentPage === index ? "2px solid #006877" : "none",
+                borderRadius: "4px",
+                width: "fit-content",
+              }}
+            >
+              {isActivityPage(page) && (
+                <PlayCircleOutlineIcon
+                  sx={{
+                    position: "absolute",
+                    top: "50%",
+                    left: "50%",
+                    transform: "translate(-50%, -50%)",
+                    fontSize: "60px",
+                    zIndex: "1",
+                  }}
+                />
+              )}
+              {isLessonPage(page) && (
+                <Thumbnail
+                  pageNumber={page.pageIndex}
+                  height={130}
+                  scale={1.66}
+                />
+              )}
+              {isActivityPage(page) && (
+                <Thumbnail
+                  pageNumber={1} // Placeholder for activity page thumbnail
+                  renderMode="custom"
+                  customRenderer={() => <Box height={215} width={280} />}
+                />
+              )}
+            </Box>
           </Box>
-        </Box>
-      ))}
-    </Box>
+        ))}
+      </Box>
+    ),
+    [currentPage, isFullScreen, module?.pages],
   );
 
   return (
@@ -191,7 +254,7 @@ const ViewModulePage = () => {
       options={options}
     >
       <Box display="flex" flexDirection="row">
-        {!isFullScreen && <SideBar />}
+        {SideBar}
         <Box
           alignItems="center"
           justifyContent="center"
@@ -261,12 +324,27 @@ const ViewModulePage = () => {
             bgcolor={isFullScreen ? "black" : "white"}
             ref={lessonPageContainerRef}
           >
-            <Page
-              pageNumber={currentPage}
-              renderAnnotationLayer={false}
-              scale={getPageScale()}
-              inputRef={lessonPageRef}
-            />
+            {currentPageObject && isLessonPage(currentPageObject) && (
+              <Page
+                pageNumber={currentPageObject.pageIndex}
+                renderAnnotationLayer={false}
+                scale={getPageScale()}
+                inputRef={lessonPageRef}
+              />
+            )}
+            {currentPageObject && isActivityPage(currentPageObject) && (
+              <Box
+                display="flex"
+                justifyContent="center"
+                alignItems="center"
+                height="100%"
+                width="100%"
+              >
+                <Typography>
+                  Activity Page for {currentPageObject.title}
+                </Typography>
+              </Box>
+            )}
           </Box>
           <Box
             height={isFullScreen ? "80px" : "48px"}
@@ -284,7 +362,7 @@ const ViewModulePage = () => {
             <Box display="flex" gap="16px">
               <IconButton
                 disabled={currentPage === 1}
-                onClick={() => setCurrentPage((curr) => curr - 1)}
+                onClick={() => setCurrentPage(currentPage - 1)}
                 sx={{
                   border: "1px solid black",
                   height: "48px",
@@ -305,7 +383,7 @@ const ViewModulePage = () => {
               </Typography>
               <IconButton
                 disabled={currentPage === numPages}
-                onClick={() => setCurrentPage((curr) => curr + 1)}
+                onClick={() => setCurrentPage(currentPage + 1)}
                 sx={{
                   border: "1px solid black",
                   height: "48px",

--- a/frontend/src/hooks/useQuery.ts
+++ b/frontend/src/hooks/useQuery.ts
@@ -1,8 +1,0 @@
-import { useMemo } from "react";
-import { useLocation } from "react-router-dom";
-
-export default function useQuery() {
-  const { search } = useLocation();
-
-  return useMemo(() => new URLSearchParams(search), [search]);
-}

--- a/frontend/src/hooks/useQueryParams.ts
+++ b/frontend/src/hooks/useQueryParams.ts
@@ -1,0 +1,22 @@
+import React from "react";
+import { useHistory, useLocation } from "react-router-dom";
+
+const useQueryParams = () => {
+  const { search } = useLocation();
+  const history = useHistory();
+
+  const queryParams = React.useMemo(
+    () => new URLSearchParams(search),
+    [search],
+  );
+
+  const setQueryParams = (queryObj: Record<string, string>) => {
+    history.push({
+      search: new URLSearchParams(queryObj).toString(),
+    });
+  };
+
+  return { queryParams, setQueryParams };
+};
+
+export default useQueryParams;

--- a/frontend/src/types/CourseTypes.ts
+++ b/frontend/src/types/CourseTypes.ts
@@ -4,10 +4,39 @@ export type CourseUnit = {
   title: string;
 };
 
+export enum PageType {
+  Lesson = "Lesson",
+  Activity = "Activity",
+}
+
+export interface CoursePage {
+  id: string;
+  title: string;
+  type: PageType;
+}
+
+export interface LessonPage extends CoursePage {
+  source: string;
+  pageIndex: number;
+}
+
+export interface ActivityPage extends CoursePage {
+  layout: [];
+}
+
+export function isLessonPage(page: CoursePage): page is LessonPage {
+  return page.type === PageType.Lesson;
+}
+
+export function isActivityPage(page: CoursePage): page is ActivityPage {
+  return page.type === PageType.Activity;
+}
+
 export type CourseModule = {
   id: string;
   displayIndex: number;
   title: string;
+  pages: [CoursePage];
 };
 
 export enum InteractiveElementType {

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1743,11 +1743,6 @@
   resolved "https://registry.yarnpkg.com/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz#4fc56c15c580b9adb7dc3c333a134e540b44bfb1"
   integrity sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==
 
-"@mui/core-downloads-tracker@^6.4.4":
-  version "6.4.4"
-  resolved "https://registry.yarnpkg.com/@mui/core-downloads-tracker/-/core-downloads-tracker-6.4.4.tgz#7ea43a1185e9cb1dbec77b9fc543b3d8a338d1f0"
-  integrity sha512-r+J0EditrekkTtO2CnCBCOGpNaDYwJqz8lH4rj6o/anDcskZFJodBlG8aCJkS8DL/CF/9EHS+Gz53EbmYEnQbw==
-
 "@mapbox/node-pre-gyp@^1.0.0":
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.11.tgz#417db42b7f5323d79e93b34a6d7a2a12c0df43fa"
@@ -1762,6 +1757,11 @@
     rimraf "^3.0.2"
     semver "^7.3.5"
     tar "^6.1.11"
+
+"@mui/core-downloads-tracker@^6.4.4":
+  version "6.4.4"
+  resolved "https://registry.yarnpkg.com/@mui/core-downloads-tracker/-/core-downloads-tracker-6.4.4.tgz#7ea43a1185e9cb1dbec77b9fc543b3d8a338d1f0"
+  integrity sha512-r+J0EditrekkTtO2CnCBCOGpNaDYwJqz8lH4rj6o/anDcskZFJodBlG8aCJkS8DL/CF/9EHS+Gz53EbmYEnQbw==
 
 "@mui/icons-material@^5.15.20":
   version "5.16.14"
@@ -3050,7 +3050,7 @@ abbrev@1:
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
   integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
 
-accepts@~1.3.4, accepts@~1.3.5, accepts@~1.3.8:
+accepts@~1.3.4, accepts@~1.3.8:
   version "1.3.8"
   resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.8.tgz#0bf0be125b67014adcb0b0921e62db7bffe16b2e"
   integrity sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==
@@ -3228,6 +3228,11 @@ are-we-there-yet@^2.0.0:
   dependencies:
     delegates "^1.0.0"
     readable-stream "^3.6.0"
+
+arg@^4.1.0:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.3.tgz#269fc7ad5b8e42cb63c896d5666017261c144089"
+  integrity sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==
 
 arg@^5.0.2:
   version "5.0.2"
@@ -5950,7 +5955,7 @@ has-unicode@^2.0.1:
   resolved "https://registry.yarnpkg.com/has-unicode/-/has-unicode-2.0.1.tgz#e0e6fe6a28cf51138855e086d1691e771de2a8b9"
   integrity sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==
 
-hasown@^2.0.0, hasown@^2.0.1, hasown@^2.0.2:
+hasown@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/hasown/-/hasown-2.0.2.tgz#003eaf91be7adc372e84ec59dc37252cedb80003"
   integrity sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==
@@ -7533,6 +7538,11 @@ make-dir@^4.0.0:
   dependencies:
     semver "^7.5.3"
 
+make-error@^1.1.1:
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
+  integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
+
 make-event-props@^1.6.0:
   version "1.6.2"
   resolved "https://registry.yarnpkg.com/make-event-props/-/make-event-props-1.6.2.tgz#c8e0e48eb28b9b808730de38359f6341de7ec5a2"
@@ -7767,15 +7777,15 @@ nan@^2.17.0:
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.22.0.tgz#31bc433fc33213c97bad36404bb68063de604de3"
   integrity sha512-nbajikzWTMwsW+eSsNm3QwlOs7het9gGJU5dDZzRTQGk03vyBOauxgI4VakDzE0PtsGTmXPsXTbbjVhRwR5mpw==
 
-nanoid@^2.1.0:
-  version "2.1.11"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-2.1.11.tgz#ec24b8a758d591561531b4176a01e3ab4f0f0280"
-  integrity sha512-s/snB+WGm6uwi0WjsZdaVcuf3KJXlfGl2LcxgwkEwJF0D/BWzVWAZW/XY4bFaiR7s0Jk3FPvlnepg1H1b1UwlA==
-
 nanoid@^3.3.7:
   version "3.3.7"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.7.tgz#d0c301a691bc8d54efa0a2226ccf3fe2fd656bd8"
   integrity sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==
+
+nanoid@^3.3.8:
+  version "3.3.8"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.8.tgz#b1be3030bee36aaff18bacb375e5cce521684baf"
+  integrity sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==
 
 natural-compare-lite@^1.4.0:
   version "1.4.0"
@@ -9825,7 +9835,7 @@ set-blocking@^2.0.0:
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
   integrity sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==
 
-set-function-length@^1.2.1:
+set-function-length@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/set-function-length/-/set-function-length-1.2.2.tgz#aac72314198eaed975cf77b2c3b6b880695e5449"
   integrity sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==
@@ -10138,7 +10148,16 @@ string-natural-compare@^3.0.1:
   resolved "https://registry.yarnpkg.com/string-natural-compare/-/string-natural-compare-3.0.1.tgz#7a42d58474454963759e8e8b7ae63d71c1e7fdf4"
   integrity sha512-n3sPwynL1nwKi3WJ6AIsClwBMa0zTi54fn2oLU6ndfTSIO05xaznjSf15PcBZU6FNWbmN5Q6cxT4V5hGvB4taw==
 
-"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -10247,7 +10266,14 @@ stringify-object@^3.3.0:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -11447,7 +11473,16 @@ workbox-window@6.6.1:
     "@types/trusted-types" "^2.0.2"
     workbox-core "6.6.1"
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Interleave Activities into Module Viewing Sidebar](https://www.notion.so/uwblueprintexecs/Interleave-Activities-into-Module-Viewing-Sidebar-18f10f3fb1dc806f8653ec7394ca6bba)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Integrated module activities into the thumbnails in the sidebar for module viewing
* Added query parameters for specifying the `moduleId` and `pageId` desired

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Go to `/view-page?moduleId={moduleId` to see activities integrated into the UI.


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Functionality and appearance of the feature


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
