### PR TITLE
Implement Create Fetch and Delete Bookmarks API for Course Pages

### DIFF
--- a/backend/middlewares/validators/userValidators.ts
+++ b/backend/middlewares/validators/userValidators.ts
@@ -1,9 +1,9 @@
-import { Request, Response, NextFunction } from "express";
+import { NextFunction, Request, Response } from "express";
 import {
   getApiValidationError,
-  validatePrimitive,
-  validateFileType,
   getFileTypeValidationError,
+  validateFileType,
+  validatePrimitive,
 } from "./util";
 
 export const uploadProfilePictureValidator = async (
@@ -77,6 +77,34 @@ export const updateUserDtoValidator = async (
   }
   if (!validatePrimitive(req.body.role, "string")) {
     return res.status(400).send(getApiValidationError("role", "string"));
+  }
+  return next();
+};
+
+export const addBookmarkValidator = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) => {
+  if (!validatePrimitive(req.body.unitId, "string")) {
+    return res.status(400).send(getApiValidationError("unitId", "string"));
+  }
+  if (!validatePrimitive(req.body.moduleId, "string")) {
+    return res.status(400).send(getApiValidationError("moduleId", "string"));
+  }
+  if (!validatePrimitive(req.body.pageId, "string")) {
+    return res.status(400).send(getApiValidationError("pageId", "string"));
+  }
+  return next();
+};
+
+export const deleteBookmarkValidator = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) => {
+  if (!validatePrimitive(req.body.pageId, "string")) {
+    return res.status(400).send(getApiValidationError("pageId", "string"));
   }
   return next();
 };

--- a/backend/models/user.mgmodel.ts
+++ b/backend/models/user.mgmodel.ts
@@ -16,9 +16,9 @@ export interface User extends Document {
 }
 
 export interface Bookmark extends CoursePage {
-  unitId: ObjectId;
-  moduleId: ObjectId; 
-  pageId: ObjectId;
+  unitId: mongoose.Types.ObjectId;
+  moduleId: mongoose.Types.ObjectId; 
+  pageId: mongoose.Types.ObjectId;
 }
 
 export interface Learner extends User {
@@ -41,9 +41,9 @@ export const BookmarkSchema: Schema = new Schema(
     type: { type: String },
     source: { type: String },
     pageIndex: { type: Number },
-    unitId: { type: mongoose.Schema.Types.ObjectId }, 
-    pageId: { type: mongoose.Schema.Types.ObjectId }, 
-    moduleId: { type: mongoose.Schema.Types.ObjectId }, 
+    unitId: { type: mongoose.Types.ObjectId }, 
+    pageId: { type: mongoose.Types.ObjectId }, 
+    moduleId: { type: mongoose.Types.ObjectId }, 
 })
 
 export const UserSchema: Schema = new Schema(

--- a/backend/models/user.mgmodel.ts
+++ b/backend/models/user.mgmodel.ts
@@ -1,6 +1,7 @@
-import mongoose, { Schema, Document, ObjectId } from "mongoose";
+import mongoose, { Document, ObjectId, Schema } from "mongoose";
 
 import { Role, Status } from "../types/userTypes";
+import { CoursePage } from "./coursepage.mgmodel";
 
 export interface User extends Document {
   id: ObjectId;
@@ -11,6 +12,13 @@ export interface User extends Document {
   status: Status;
   email: string;
   profilePicture?: string;
+  bookmarks: Bookmark[];
+}
+
+export interface Bookmark extends CoursePage {
+  unitId: ObjectId;
+  moduleId: ObjectId; 
+  pageId: ObjectId;
 }
 
 export interface Learner extends User {
@@ -25,6 +33,18 @@ const baseOptions = {
   discriminatorKey: "role",
   timestamps: true,
 };
+
+export const BookmarkSchema: Schema = new Schema(
+  {
+    id: { type: mongoose.Schema.Types.ObjectId }, 
+    title: { type: String },
+    type: { type: String },
+    source: { type: String },
+    pageIndex: { type: Number },
+    unitId: { type: mongoose.Schema.Types.ObjectId }, 
+    pageId: { type: mongoose.Schema.Types.ObjectId }, 
+    moduleId: { type: mongoose.Schema.Types.ObjectId }, 
+})
 
 export const UserSchema: Schema = new Schema(
   {
@@ -57,6 +77,10 @@ export const UserSchema: Schema = new Schema(
     profilePicture: {
       type: String,
     },
+    bookmarks: {
+      type: [BookmarkSchema],
+      required: true,
+    }
   },
   baseOptions,
 );

--- a/backend/models/user.mgmodel.ts
+++ b/backend/models/user.mgmodel.ts
@@ -1,7 +1,6 @@
 import mongoose, { Document, ObjectId, Schema } from "mongoose";
 
 import { Role, Status } from "../types/userTypes";
-import { CoursePage } from "./coursepage.mgmodel";
 
 export interface User extends Document {
   id: ObjectId;
@@ -15,9 +14,12 @@ export interface User extends Document {
   bookmarks: Bookmark[];
 }
 
-export interface Bookmark extends CoursePage {
+export interface Bookmark {
+  id: mongoose.Types.ObjectId;
+  title: string;
+  type: string;
   unitId: mongoose.Types.ObjectId;
-  moduleId: mongoose.Types.ObjectId; 
+  moduleId: mongoose.Types.ObjectId;
   pageId: mongoose.Types.ObjectId;
 }
 
@@ -34,17 +36,14 @@ const baseOptions = {
   timestamps: true,
 };
 
-export const BookmarkSchema: Schema = new Schema(
-  {
-    id: { type: mongoose.Schema.Types.ObjectId }, 
-    title: { type: String },
-    type: { type: String },
-    source: { type: String },
-    pageIndex: { type: Number },
-    unitId: { type: mongoose.Types.ObjectId }, 
-    pageId: { type: mongoose.Types.ObjectId }, 
-    moduleId: { type: mongoose.Types.ObjectId }, 
-})
+export const BookmarkSchema: Schema = new Schema({
+  id: { type: mongoose.Schema.Types.ObjectId },
+  title: { type: String },
+  type: { type: String },
+  unitId: { type: mongoose.Types.ObjectId },
+  pageId: { type: mongoose.Types.ObjectId },
+  moduleId: { type: mongoose.Types.ObjectId },
+});
 
 export const UserSchema: Schema = new Schema(
   {
@@ -79,8 +78,9 @@ export const UserSchema: Schema = new Schema(
     },
     bookmarks: {
       type: [BookmarkSchema],
+      default: [],
       required: true,
-    }
+    },
   },
   baseOptions,
 );

--- a/backend/rest/userRoutes.ts
+++ b/backend/rest/userRoutes.ts
@@ -6,6 +6,7 @@ import {
   updateUserDtoValidator,
   uploadProfilePictureValidator,
 } from "../middlewares/validators/userValidators";
+import UserModel from "../models/user.mgmodel";
 import nodemailerConfig from "../nodemailer.config";
 import AuthService from "../services/implementations/authService";
 import CoursePageService from "../services/implementations/coursePageService";
@@ -16,6 +17,7 @@ import IAuthService from "../services/interfaces/authService";
 import ICoursePageService from "../services/interfaces/coursePageService";
 import IEmailService from "../services/interfaces/emailService";
 import IUserService from "../services/interfaces/userService";
+import { CoursePageDTO } from "../types/courseTypes";
 import {
   BookmarkDTO,
   UpdateUserDTO,
@@ -81,17 +83,24 @@ userRouter.post(
         accessToken!,
       );
 
-      const user = await userService.getUserById(userId.toString())
-      const page = await coursePageService.getCoursePage(pageId)
+      const user: UserDTO = await userService.getUserById(userId.toString());
+      const page: CoursePageDTO = await coursePageService.getCoursePage(pageId);
+
       const bookmark: BookmarkDTO = {
         ...page,
         unitId,
         moduleId,
         pageId,
-      }
+      };
+
+      await UserModel.findByIdAndUpdate(
+        userId,
+        { $push: { bookmarks: user.bookmarks.push(bookmark) } },
+        { runValidators: true },
+      );
 
     } catch(error: any) {
-
+      res.status(500).json({ error: getErrorMessage(error) });
     }
 
   }

--- a/backend/rest/userRoutes.ts
+++ b/backend/rest/userRoutes.ts
@@ -18,7 +18,6 @@ import IAuthService from "../services/interfaces/authService";
 import ICoursePageService from "../services/interfaces/coursePageService";
 import IEmailService from "../services/interfaces/emailService";
 import IUserService from "../services/interfaces/userService";
-import { CoursePageDTO } from "../types/courseTypes";
 import {
   UpdateUserDTO,
   UserDTO,
@@ -84,19 +83,19 @@ userRouter.post(
 
 
       const user: UserDTO = await userService.getUserById(userId.toString());
-      const page: CoursePageDTO = await coursePageService.getCoursePage(pageId);
-      let bookmark;
+      const page = await coursePageService.getCoursePage(pageId);
 
-      if (typeof unitId === "string" && typeof moduleId === "string" && typeof pageId === "string" ) {
-        bookmark = {
-          ...page,
-          unitId: new mongoose.Types.ObjectId(unitId),
-          moduleId: new mongoose.Types.ObjectId(moduleId),
-          pageId: new mongoose.Types.ObjectId(pageId),
-        };
+      if (typeof unitId !== "string" || typeof moduleId !== "string" || typeof pageId !== "string" ) {
+        throw new Error("Invalid unitId, moduleId, or pageId: should be strings")
       }
 
-      console.log(bookmark)
+      const bookmark = {
+        ...page,
+        id: new mongoose.Types.ObjectId(page.id),
+        unitId: new mongoose.Types.ObjectId(unitId),
+        moduleId: new mongoose.Types.ObjectId(moduleId),
+        pageId: new mongoose.Types.ObjectId(pageId),
+      };
 
       const new_user = await UserModel.findByIdAndUpdate(
         userId,

--- a/backend/services/implementations/coursePageService.ts
+++ b/backend/services/implementations/coursePageService.ts
@@ -1,17 +1,17 @@
 /* eslint-disable class-methods-use-this */
 import { startSession } from "mongoose";
+import MgCourseModule, {
+  CourseModule,
+} from "../../models/coursemodule.mgmodel";
+import MgCoursePage from "../../models/coursepage.mgmodel";
 import {
   CoursePageDTO,
   CreateCoursePageDTO,
   UpdateCoursePageDTO,
 } from "../../types/courseTypes";
+import { getErrorMessage } from "../../utilities/errorUtils";
 import logger from "../../utilities/logger";
 import ICoursePageService from "../interfaces/coursePageService";
-import MgCourseModule, {
-  CourseModule,
-} from "../../models/coursemodule.mgmodel";
-import MgCoursePage from "../../models/coursepage.mgmodel";
-import { getErrorMessage } from "../../utilities/errorUtils";
 
 const Logger = logger(__filename);
 
@@ -45,9 +45,14 @@ class CoursePageService implements ICoursePageService {
     }
   }
 
-  async getCoursePage(coursePageId: string): Promise<CoursePageDTO> {
+  async getCoursePage(
+    coursePageId: string,
+    lean = false,
+  ): Promise<CoursePageDTO> {
     try {
-      const coursePage = await MgCoursePage.findById(coursePageId);
+      const coursePage = lean
+        ? await MgCoursePage.findById(coursePageId).lean().exec()
+        : await MgCoursePage.findById(coursePageId);
 
       if (!coursePage) {
         throw new Error(`id ${coursePageId} not found.`);

--- a/backend/services/implementations/userService.ts
+++ b/backend/services/implementations/userService.ts
@@ -131,7 +131,7 @@ class UserService implements IUserService {
           role: user.role,
           status: user.status,
           email: user.email,
-          bookmarks: []
+          bookmarks: [],
         });
       } catch (mongoDbError) {
         // rollback user creation in Firebase

--- a/backend/services/implementations/userService.ts
+++ b/backend/services/implementations/userService.ts
@@ -131,6 +131,7 @@ class UserService implements IUserService {
           role: user.role,
           status: user.status,
           email: user.email,
+          bookmarks: []
         });
       } catch (mongoDbError) {
         // rollback user creation in Firebase

--- a/backend/services/interfaces/coursePageService.ts
+++ b/backend/services/interfaces/coursePageService.ts
@@ -17,7 +17,7 @@ interface ICoursePageService {
    * @param coursePageId the id of the page we want to fetch
    * @throwsError if course page was not successfully fetched or not found
    */
-  getCoursePage(coursePageId: string): Promise<CoursePageDTO>;
+  getCoursePage(coursePageId: string, lean?: boolean): Promise<CoursePageDTO>;
 
   /**
    * Creates a course page, appended as the last page in the module (for now)

--- a/backend/types/userTypes.ts
+++ b/backend/types/userTypes.ts
@@ -1,4 +1,5 @@
 import { CoursePageDTO } from "./courseTypes";
+
 export type Role = "Administrator" | "Facilitator" | "Learner";
 
 export function isRole(role: string): role is Role {
@@ -11,9 +12,9 @@ export type Status = "Invited" | "Active";
 
 export type BookmarkDTO = CoursePageDTO & {
   unitId: string;
-  moduleId: string; 
+  moduleId: string;
   pageId: string;
-}
+};
 
 export type UserDTO = {
   id: string;
@@ -23,10 +24,12 @@ export type UserDTO = {
   role: Role;
   status: Status;
   profilePicture?: string;
-  bookmarks: BookmarkDTO[]
+  bookmarks: BookmarkDTO[];
 };
 
-export type CreateUserDTO = Omit<UserDTO, "id" | "bookmarks"> & { password: string };
+export type CreateUserDTO = Omit<UserDTO, "id" | "bookmarks"> & {
+  password: string;
+};
 
 export type UpdateUserDTO = Omit<UserDTO, "id" | "bookmarks">;
 

--- a/backend/types/userTypes.ts
+++ b/backend/types/userTypes.ts
@@ -1,3 +1,4 @@
+import { CoursePageDTO } from "./courseTypes";
 export type Role = "Administrator" | "Facilitator" | "Learner";
 
 export function isRole(role: string): role is Role {
@@ -8,6 +9,12 @@ export function isRole(role: string): role is Role {
 
 export type Status = "Invited" | "Active";
 
+export type BookmarkDTO = CoursePageDTO & {
+  unitId: string;
+  moduleId: string; 
+  pageId: string;
+}
+
 export type UserDTO = {
   id: string;
   firstName: string;
@@ -16,11 +23,12 @@ export type UserDTO = {
   role: Role;
   status: Status;
   profilePicture?: string;
+  bookmarks: BookmarkDTO[]
 };
 
-export type CreateUserDTO = Omit<UserDTO, "id"> & { password: string };
+export type CreateUserDTO = Omit<UserDTO, "id" | "bookmarks"> & { password: string };
 
-export type UpdateUserDTO = Omit<UserDTO, "id">;
+export type UpdateUserDTO = Omit<UserDTO, "id" | "bookmarks">;
 
 export type SignupUserDTO = Omit<CreateUserDTO, "role">;
 


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Course Page Bookmark API](https://www.notion.so/uwblueprintexecs/Course-Page-Bookmark-API-1ab10f3fb1dc803b847ac74ba40e24f8)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Made a `bookmarks` array attribute to the `User` schema and type to store a user's bookmarks
  * Refer to types and model files for the structure of the `Bookmark` type
* Creating and deleting bookmarks are handled in their own respective routes
* Fetching a bookmark will come from fetching the `User` itself and accessing the `bookmarks` array.


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Use Postman to `POST /users/addBookmark` with the following (example) fields:
```
{
    "moduleId": "6775be1afa8027fddf428b3f",
    "unitId": "66849975902163df7453daea",
    "pageId": "67cb4cc6eda7be8d18c60ae4"
}
```
2. Check that a bookmark has been successfully created (ignore the preview of the bookmarks array for now)
3. Check that creating multiple bookmarks with the same `pageId` throws an error
4. Try deleting the bookmark with `POST /users/deleteBookmark`. You only need to provide `pageId` for this endpoint.


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Functionality of the feature!


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
