### PR TITLE
added endpoint to rearrange units

### DIFF
--- a/backend/rest/courseRoutes.ts
+++ b/backend/rest/courseRoutes.ts
@@ -15,6 +15,7 @@ import CoursePageService from "../services/implementations/coursePageService";
 import CourseUnitService from "../services/implementations/courseUnitService";
 import FileStorageService from "../services/implementations/fileStorageService";
 import { getErrorMessage } from "../utilities/errorUtils";
+import { CourseUnitDTO } from "../types/courseTypes";
 
 const storage = multer.memoryStorage();
 const upload = multer({ storage });
@@ -58,6 +59,48 @@ courseRouter.post(
       res.status(200).json(imageURL);
     } catch (e: unknown) {
       res.status(500).send(getErrorMessage(e));
+    }
+  },
+);
+
+courseRouter.put(
+  "/rearangeUnits",
+  isAuthorizedByRole(new Set(["Administrator", "Facilitator"])),
+  async (req, res) => {
+    try {
+      const arangement: Map<string, number> = new Map<string, number>(
+        Object.entries(req.body.arangement),
+      );
+      const courseUnits = await courseUnitService.getCourseUnits();
+      const updatedUnits: CourseUnitDTO[] = [];
+      const maxIndex: number = courseUnits.length;
+      const testSet: Set<number> = new Set();
+      arangement.forEach((value, key) => {
+        if (value > maxIndex || value < 1) {
+          throw Error("invalid arangement");
+        }
+        const unit: CourseUnitDTO | undefined = courseUnits.find(
+          (units) => units.id === key,
+        );
+        if (unit) {
+          unit.displayIndex = value;
+          updatedUnits.push(unit);
+        } else {
+          throw Error("invalid arangement");
+        }
+      });
+      courseUnits.forEach((unit) => {
+        testSet.add(unit.displayIndex);
+      });
+      if (testSet.size !== maxIndex) {
+        throw Error("invalid arangement");
+      }
+      updatedUnits.forEach(async (unit) => {
+        await courseUnitService.updateCourseUnit(unit.id, unit);
+      });
+      res.status(200).send("success");
+    } catch (error: unknown) {
+      res.status(500).send(getErrorMessage(error));
     }
   },
 );

--- a/backend/services/implementations/courseUnitService.ts
+++ b/backend/services/implementations/courseUnitService.ts
@@ -73,13 +73,10 @@ class CourseUnitService implements ICourseUnitService {
   ): Promise<CourseUnitDTO> {
     try {
       const updatedCourseUnit: CourseUnit | null =
-        await MgCourseUnit.findByIdAndUpdate(
-          id,
-          {
-            title: courseUnit.title,
-          },
-          { runValidators: true, new: true },
-        );
+        await MgCourseUnit.findByIdAndUpdate(id, courseUnit, {
+          runValidators: true,
+          new: true,
+        });
 
       if (!updatedCourseUnit) {
         throw new Error(`Course unit with id ${id} not found.`);

--- a/backend/types/courseTypes.ts
+++ b/backend/types/courseTypes.ts
@@ -6,7 +6,9 @@ export type CourseUnitDTO = {
 };
 
 export type CreateCourseUnitDTO = Pick<CourseUnitDTO, "title">;
-export type UpdateCourseUnitDTO = Pick<CourseUnitDTO, "title">;
+export type UpdateCourseUnitDTO = Partial<
+  Pick<CourseUnitDTO, "title" | "displayIndex">
+>;
 
 export type CourseModuleDTO = {
   id: string;


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Unit Rearranging Backend](https://www.notion.so/uwblueprintexecs/Unit-Rearranging-Backend-20210f3fb1dc80ce884adfd718fb2371?source=copy_link)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
The front-end is required to send a map of the units which have been rearranged with the key as the unit id and value as the new display index. This end point makes changes to the database so the arrangement is permanent. It also validates the arrangement sent as in if the frontend sends invalid display index or accidentally sends a map which 2 units having the same display index, it responds with a 500 error. 


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1.  from post man call course/rearangeUnits with a body field arangement which is a map of the units that need to be rearranged as described above. This is a sample of the body
<img width="404" alt="image" src="https://github.com/user-attachments/assets/3ec392de-212c-4044-93f0-d8b3a72eae7f" />



<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* make sure to throughly check for invalid arrangements 


## Checklist
- [ ] My PR name is descriptive and in imperative tense
- [ ] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [ ] I have run the appropriate linter(s)
- [ ] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
