### PR TITLE
Refactor colours to match Figma

### DIFF
--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -31,6 +31,14 @@ module.exports = {
     "react/no-array-index-key": "off",
     "jsx-a11y/click-events-have-key-events": "off",
     "jsx-a11y/no-static-element-interactions": "off",
+    // Using the new React 17+ JSX transform (tsconfig jsx: "react-jsx"), so importing React in scope is unnecessary.
+    // Disable legacy rules that still expect an explicit import.
+    "react/react-in-jsx-scope": "off",
+    "react/jsx-uses-react": "off",
   },
-  ignorePatterns: ["build/*", ".eslintrc.js", "src/theme/themeAugmentation.d.ts"],
+  ignorePatterns: [
+    "build/*",
+    ".eslintrc.js",
+    "src/theme/themeAugmentation.d.ts",
+  ],
 };

--- a/frontend/src/components/auth/CreatePasswordConfirmationPage.tsx
+++ b/frontend/src/components/auth/CreatePasswordConfirmationPage.tsx
@@ -1,10 +1,10 @@
-import React from "react";
-import { Container, Typography, Button, Box, useTheme } from "@mui/material";
 import CheckCircleOutlineIcon from "@mui/icons-material/CheckCircleOutline";
+import { Box, Button, Container, Typography, useTheme } from "@mui/material";
+import React from "react";
 import { useHistory } from "react-router-dom";
-import Logo from "../assets/logoColoured.png";
 import { LANDING_PAGE } from "../../constants/Routes";
 import { useUser } from "../../hooks/useUser";
+import Logo from "../assets/logoColoured.png";
 
 const CreatePasswordConfirmationPage = (): React.ReactElement => {
   const user = useUser();
@@ -96,7 +96,7 @@ const CreatePasswordConfirmationPage = (): React.ReactElement => {
             alignItems: "center",
             gap: theme.spacing(1),
             borderRadius: "4px",
-            background: theme.palette[`${user.role}`].Default,
+            background: theme.palette[`${user.role}`].Dark.Default,
             color: theme.palette.Neutral[100],
             textAlign: "center",
             fontSize: theme.typography.labelLarge.fontSize,
@@ -106,7 +106,7 @@ const CreatePasswordConfirmationPage = (): React.ReactElement => {
             letterSpacing: theme.typography.labelLarge.letterSpacing,
             textTransform: theme.typography.labelLarge.textTransform,
             "&:hover": {
-              background: theme.palette[`${user.role}`].Pressed,
+              background: theme.palette[`${user.role}`].Dark.Pressed,
             },
           }}
           onClick={handleBackToHome}

--- a/frontend/src/components/auth/CreatePasswordPage.tsx
+++ b/frontend/src/components/auth/CreatePasswordPage.tsx
@@ -1,15 +1,15 @@
+import { Box, Button, Container, Typography, useTheme } from "@mui/material";
 import React, { useContext, useState } from "react";
-import { Box, Container, Typography, Button, useTheme } from "@mui/material";
 import { Redirect } from "react-router-dom";
+import AuthAPIClient from "../../APIClients/AuthAPIClient";
+import AUTHENTICATED_USER_KEY from "../../constants/AuthConstants";
+import { LANDING_PAGE } from "../../constants/Routes";
+import AuthContext from "../../contexts/AuthContext";
+import { useUser } from "../../hooks/useUser";
 import Logo from "../assets/logoColoured.png";
 import CreatePasswordHelpModal from "../help/CreatePasswordHelpModal";
 import CreatePasswordConfirmationPage from "./CreatePasswordConfirmationPage";
 import PasswordCheck from "./PasswordCheck";
-import { useUser } from "../../hooks/useUser";
-import { LANDING_PAGE } from "../../constants/Routes";
-import AuthAPIClient from "../../APIClients/AuthAPIClient";
-import AuthContext from "../../contexts/AuthContext";
-import AUTHENTICATED_USER_KEY from "../../constants/AuthConstants";
 
 const CreatePasswordPage = (): React.ReactElement => {
   const user = useUser();
@@ -139,9 +139,9 @@ const CreatePasswordPage = (): React.ReactElement => {
                 padding: "10px 24px",
                 width: "100%",
                 textTransform: "none",
-                backgroundColor: theme.palette[`${user.role}`].Default,
+                backgroundColor: theme.palette[`${user.role}`].Dark.Default,
                 "&:hover": {
-                  background: theme.palette[`${user.role}`].Pressed,
+                  background: theme.palette[`${user.role}`].Dark.Pressed,
                 },
                 "&.Mui-disabled": {
                   backgroundColor: "#ccc",
@@ -157,7 +157,7 @@ const CreatePasswordPage = (): React.ReactElement => {
                   textAlign: "right",
                   marginTop: 2,
                   marginRight: "12px",
-                  color: theme.palette.Learner.Default,
+                  color: theme.palette.Learner.Dark.Default,
                   cursor: "pointer",
                   "&:hover": {
                     textDecoration: "underline",

--- a/frontend/src/components/auth/Login.tsx
+++ b/frontend/src/components/auth/Login.tsx
@@ -1,6 +1,6 @@
+import { Box, Container, Link, Typography, useTheme } from "@mui/material";
 import React, { useContext, useState } from "react";
 import { Redirect } from "react-router-dom";
-import { Box, Container, Link, Typography, useTheme } from "@mui/material";
 import { LANDING_PAGE } from "../../constants/Routes";
 import AuthContext from "../../contexts/AuthContext";
 import { Role } from "../../types/AuthTypes";
@@ -44,7 +44,7 @@ const Login: React.FC<LoginProps> = ({
         <Box>
           <Typography
             variant="headlineMedium"
-            sx={{ color: theme.palette.Administrator.Pressed }}
+            sx={{ color: theme.palette.Administrator.Dark.Pressed }}
           >
             {title}
           </Typography>
@@ -52,7 +52,7 @@ const Login: React.FC<LoginProps> = ({
         <Box marginTop="12px">
           <Typography
             variant="bodyMedium"
-            sx={{ color: theme.palette.Administrator.Pressed }}
+            sx={{ color: theme.palette.Administrator.Dark.Pressed }}
           >
             {description}
           </Typography>
@@ -93,7 +93,7 @@ const Login: React.FC<LoginProps> = ({
                     <Typography
                       variant="labelSmall"
                       style={{
-                        color: theme.palette[userRole].Default,
+                        color: theme.palette[userRole].Dark.Default,
                         textTransform: "uppercase",
                       }}
                     >
@@ -107,7 +107,7 @@ const Login: React.FC<LoginProps> = ({
                   <Typography
                     variant="labelSmall"
                     style={{
-                      color: theme.palette[userRole].Default,
+                      color: theme.palette[userRole].Dark.Default,
                     }}
                     onClick={() => setShowDrawerLogin(false)}
                     sx={{ cursor: "pointer" }}

--- a/frontend/src/components/auth/LoginForm.tsx
+++ b/frontend/src/components/auth/LoginForm.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState } from "react";
+import { AlternateEmail, Password } from "@mui/icons-material";
 import {
   Box,
   Button,
@@ -8,19 +8,19 @@ import {
   Typography,
   useTheme,
 } from "@mui/material";
-import { AlternateEmail, Password } from "@mui/icons-material";
 import InputAdornment from "@mui/material/InputAdornment";
-import { AuthenticatedUser, AuthError, Role } from "../../types/AuthTypes";
-import AUTHENTICATED_USER_KEY from "../../constants/AuthConstants";
-import { PresentableError } from "../../types/ErrorTypes";
-import { FORGOT_PASSWORD_PAGE } from "../../constants/Routes";
+import { useContext, useState } from "react";
 import authAPIClient from "../../APIClients/AuthAPIClient";
+import AUTHENTICATED_USER_KEY from "../../constants/AuthConstants";
+import { FORGOT_PASSWORD_PAGE } from "../../constants/Routes";
 import AuthContext from "../../contexts/AuthContext";
 import {
   AuthErrorCodes,
   authErrors,
   defaultAuthError,
 } from "../../errors/AuthErrors";
+import { AuthenticatedUser, AuthError, Role } from "../../types/AuthTypes";
+import { PresentableError } from "../../types/ErrorTypes";
 import { capitalizeFirstLetter } from "../../utils/StringUtils";
 import ErrorAlert from "../common/ErrorAlert";
 
@@ -156,7 +156,7 @@ const LoginForm = ({ userRole }: LoginFormProps) => {
                 alignSelf: "stretch",
                 maxHeight: "56px",
                 "& .MuiFormHelperText-root": {
-                  color: theme.palette.Error.Default,
+                  color: theme.palette.Error.Dark.Default,
                 },
               }}
             />
@@ -179,7 +179,7 @@ const LoginForm = ({ userRole }: LoginFormProps) => {
                 alignSelf: "stretch",
                 maxHeight: "56px",
                 "& .MuiFormHelperText-root": {
-                  color: theme.palette.Error.Default,
+                  color: theme.palette.Error.Dark.Default,
                 },
               }}
               InputProps={{
@@ -197,8 +197,8 @@ const LoginForm = ({ userRole }: LoginFormProps) => {
                   variant="bodySmall"
                   style={{
                     color: passwordError
-                      ? theme.palette.Error.Default
-                      : theme.palette[userRole].Default,
+                      ? theme.palette.Error.Dark.Default
+                      : theme.palette[userRole].Dark.Default,
                   }}
                 >
                   Forgot Password
@@ -218,7 +218,7 @@ const LoginForm = ({ userRole }: LoginFormProps) => {
               justifyContent: "center",
               alignItems: "center",
               borderRadius: "4px",
-              backgroundColor: theme.palette[userRole].Default,
+              backgroundColor: theme.palette[userRole].Dark.Default,
               boxShadow: "none",
             }}
           >

--- a/frontend/src/components/auth/SignupPage.tsx
+++ b/frontend/src/components/auth/SignupPage.tsx
@@ -1,5 +1,4 @@
-import React, { useContext, useState } from "react";
-import { Redirect } from "react-router-dom";
+import { AlternateEmail, BadgeOutlined, Close } from "@mui/icons-material";
 import {
   Box,
   Button,
@@ -14,21 +13,22 @@ import {
   Typography,
   useTheme,
 } from "@mui/material";
-import { AlternateEmail, BadgeOutlined, Close } from "@mui/icons-material";
+import React, { useContext, useState } from "react";
+import { Redirect } from "react-router-dom";
 import AuthAPIClient from "../../APIClients/AuthAPIClient";
 import { LANDING_PAGE, WELCOME_PAGE } from "../../constants/Routes";
 import AuthContext from "../../contexts/AuthContext";
-import logo from "../assets/logoColoured.png";
-import { getSignUpPath, getSignUpPrompt } from "./WelcomePage";
-import Login from "./Login";
 import {
   AuthErrorCodes,
   authErrors,
   defaultAuthError,
 } from "../../errors/AuthErrors";
 import { PresentableError } from "../../types/ErrorTypes";
+import logo from "../assets/logoColoured.png";
 import ErrorAlert from "../common/ErrorAlert";
+import Login from "./Login";
 import PasswordCheck from "./PasswordCheck";
+import { getSignUpPath, getSignUpPrompt } from "./WelcomePage";
 
 const Signup = (): React.ReactElement => {
   const { authenticatedUser } = useContext(AuthContext);
@@ -231,7 +231,7 @@ const Signup = (): React.ReactElement => {
               disabled={!isPasswordValid}
               fullWidth
               sx={{
-                bgcolor: theme.palette.Facilitator.Default,
+                bgcolor: theme.palette.Facilitator.Dark.Default,
                 display: "flex",
                 flexDirection: "column",
                 padding: "20px 24px",
@@ -240,7 +240,7 @@ const Signup = (): React.ReactElement => {
                 gap: "8px",
                 alignSelf: "stretch",
                 "&:hover": {
-                  bgcolor: theme.palette.Facilitator.Default,
+                  bgcolor: theme.palette.Facilitator.Dark.Default,
                 },
               }}
             >
@@ -253,7 +253,7 @@ const Signup = (): React.ReactElement => {
                 <Typography
                   variant="labelSmall"
                   sx={{
-                    color: theme.palette.Facilitator.Default,
+                    color: theme.palette.Facilitator.Dark.Default,
                     position: "absolute",
                     left: 0,
                   }}
@@ -276,7 +276,7 @@ const Signup = (): React.ReactElement => {
                 <Typography
                   variant="labelSmall"
                   sx={{
-                    color: theme.palette.Facilitator.Default,
+                    color: theme.palette.Facilitator.Dark.Default,
                     position: "absolute",
                     right: 0,
                   }}

--- a/frontend/src/components/auth/WelcomePage.tsx
+++ b/frontend/src/components/auth/WelcomePage.tsx
@@ -1,3 +1,5 @@
+import ArrowForwardIcon from "@mui/icons-material/ArrowForward";
+import CloseIcon from "@mui/icons-material/Close";
 import {
   Box,
   Button,
@@ -10,16 +12,14 @@ import {
   Typography,
   useTheme,
 } from "@mui/material";
-import CloseIcon from "@mui/icons-material/Close";
-import ArrowForwardIcon from "@mui/icons-material/ArrowForward";
 import React, { useContext, useState } from "react";
 import { Redirect } from "react-router-dom";
 import { LANDING_PAGE, SIGNUP_PAGE } from "../../constants/Routes";
 import AuthContext from "../../contexts/AuthContext";
+import { Role } from "../../types/AuthTypes";
 import background from "../assets/backgroundImage.png";
 import logo from "../assets/logoWhite.png";
 import Login from "./Login";
-import { Role } from "../../types/AuthTypes";
 
 export const getSignUpPrompt = (role: Role): string | undefined => {
   if (role === "Administrator") {
@@ -73,7 +73,7 @@ const Welcome = (): React.ReactElement => {
           sx={{
             width: "100%",
             height: "100%",
-            backgroundColor: theme.palette[userRole].Hover,
+            backgroundColor: theme.palette[userRole].Light.Hover,
             justifyContent: "space-between",
             display: "flex",
             alignItems: "center",
@@ -81,7 +81,7 @@ const Welcome = (): React.ReactElement => {
             textTransform: "none",
             borderRadius: "8px",
             "&:hover": {
-              bgcolor: theme.palette[userRole].Hover,
+              bgcolor: theme.palette[userRole].Light.Hover,
             },
           }}
           onClick={() => handleButtonClick(userRole)}
@@ -89,12 +89,14 @@ const Welcome = (): React.ReactElement => {
           <Typography
             variant="bodyLarge"
             style={{
-              color: theme.palette[userRole].Pressed,
+              color: theme.palette[userRole].Dark.Pressed,
             }}
           >
             {buttonText}
           </Typography>
-          <ArrowForwardIcon sx={{ color: theme.palette[userRole].Pressed }} />
+          <ArrowForwardIcon
+            sx={{ color: theme.palette[userRole].Dark.Pressed }}
+          />
         </Button>
       </Box>
     );
@@ -295,7 +297,7 @@ const Welcome = (): React.ReactElement => {
             flexDirection: "row",
             justifyContent: "space-between",
             alignItems: "stretch",
-            backgroundColor: theme.palette.Learner.Light,
+            backgroundColor: theme.palette.Learner.Light.Default,
           }}
           disableGutters
         >
@@ -368,14 +370,14 @@ const Welcome = (): React.ReactElement => {
           title="Learners"
           description="The person who is learning about money."
           instruction="Ask a facilitator to setup your account."
-          backgroundColor={theme.palette.Learner.Light}
-          borderColor={theme.palette.Learner.Default}
+          backgroundColor={theme.palette.Learner.Light.Default}
+          borderColor={theme.palette.Learner.Dark.Default}
         />
         <InfoBox
           title="Facilitators"
           description="The person who is helping people learn about money."
           backgroundColor={`${theme.palette.Facilitator.Light}`}
-          borderColor={theme.palette.Facilitator.Default}
+          borderColor={theme.palette.Facilitator.Dark.Default}
           signUpRedirect
         />
         <InfoBox
@@ -383,7 +385,7 @@ const Welcome = (): React.ReactElement => {
           description="The person who monitors the program."
           instruction="Ask an existing administrator to help setup your account."
           backgroundColor={`${theme.palette.Administrator.Light}`}
-          borderColor={theme.palette.Administrator.Default}
+          borderColor={theme.palette.Administrator.Dark.Default}
         />
       </Container>
 

--- a/frontend/src/components/auth/forgot_password/ForgotPasswordConfirmation.tsx
+++ b/frontend/src/components/auth/forgot_password/ForgotPasswordConfirmation.tsx
@@ -1,13 +1,13 @@
-import React, { useEffect, useState } from "react";
+import SendIcon from "@mui/icons-material/Send";
 import {
-  Container,
-  Typography,
-  useTheme,
-  Snackbar,
   Box,
   Button,
+  Container,
+  Snackbar,
+  Typography,
+  useTheme,
 } from "@mui/material";
-import SendIcon from "@mui/icons-material/Send";
+import React, { useEffect, useState } from "react";
 import authAPIClient from "../../../APIClients/AuthAPIClient";
 
 interface ForgotPasswordConfirmationProps {
@@ -99,7 +99,7 @@ const ForgotPasswordConfirmation: React.FC<ForgotPasswordConfirmationProps> = ({
             variant="labelSmall"
             onClick={onBackToEmail}
             sx={{
-              color: theme.palette.Learner.Default,
+              color: theme.palette.Learner.Dark.Default,
               padding: 0,
             }}
           >
@@ -113,7 +113,7 @@ const ForgotPasswordConfirmation: React.FC<ForgotPasswordConfirmationProps> = ({
               onClick={handleResendEmail}
               sx={{
                 color: canResend
-                  ? theme.palette.Learner.Default
+                  ? theme.palette.Learner.Dark.Default
                   : theme.palette.text?.disabled,
                 padding: 0,
               }}
@@ -127,7 +127,7 @@ const ForgotPasswordConfirmation: React.FC<ForgotPasswordConfirmationProps> = ({
             onClick={handleResendEmail}
             sx={{
               color: canResend
-                ? theme.palette.Learner.Default
+                ? theme.palette.Learner.Dark.Default
                 : theme.palette.text?.disabled,
               padding: 0,
             }}
@@ -176,11 +176,11 @@ const ForgotPasswordConfirmation: React.FC<ForgotPasswordConfirmationProps> = ({
         >
           <SendIcon
             sx={{
-              color: theme.palette.Success.Default,
+              color: theme.palette.Success.Dark.Default,
               marginRight: "16px",
             }}
           />
-          <Typography sx={{ color: theme.palette.Success.Default }}>
+          <Typography sx={{ color: theme.palette.Success.Dark.Default }}>
             {`A new reset email has been sent. 
             Please check your inbox (and spam folder).`}
           </Typography>

--- a/frontend/src/components/auth/forgot_password/ForgotPasswordPage.tsx
+++ b/frontend/src/components/auth/forgot_password/ForgotPasswordPage.tsx
@@ -1,19 +1,19 @@
-import React, { useState, useContext } from "react";
+import AlternateEmailIcon from "@mui/icons-material/AlternateEmail";
 import {
-  Container,
-  TextField,
   Button,
-  Typography,
+  Container,
   InputAdornment,
+  TextField,
+  Typography,
   useTheme,
 } from "@mui/material";
-import AlternateEmailIcon from "@mui/icons-material/AlternateEmail";
-import { useHistory, Redirect } from "react-router-dom";
+import React, { useContext, useState } from "react";
+import { Redirect, useHistory } from "react-router-dom";
 
-import AuthContext from "../../../contexts/AuthContext";
-import ForgotPasswordConfirmation from "./ForgotPasswordConfirmation";
 import authAPIClient from "../../../APIClients/AuthAPIClient";
 import { LANDING_PAGE, WELCOME_PAGE } from "../../../constants/Routes";
+import AuthContext from "../../../contexts/AuthContext";
+import ForgotPasswordConfirmation from "./ForgotPasswordConfirmation";
 
 const ForgotPasswordPage = (): React.ReactElement => {
   const [email, setEmail] = useState("");
@@ -147,14 +147,14 @@ const ForgotPasswordPage = (): React.ReactElement => {
                 gap: 1,
                 borderRadius: 1,
                 width: 500,
-                backgroundColor: theme.palette.Learner.Default,
+                backgroundColor: theme.palette.Learner.Dark.Default,
                 color: theme.palette.Neutral[300],
                 marginTop: 4,
                 "&:hover": {
                   backgroundColor: "#002A32",
                 },
                 "&:active": {
-                  backgroundColor: theme.palette.Learner.Pressed,
+                  backgroundColor: theme.palette.Learner.Dark.Pressed,
                 },
               }}
             >
@@ -165,7 +165,7 @@ const ForgotPasswordPage = (): React.ReactElement => {
             <Button variant="text" sx={{ padding: 0 }}>
               <Typography
                 variant="labelSmall"
-                sx={{ color: theme.palette.Learner.Default }}
+                sx={{ color: theme.palette.Learner.Dark.Default }}
                 onClick={handleBackToLogin}
               >
                 Remember your password? Back to Login

--- a/frontend/src/components/common/ErrorAlert.tsx
+++ b/frontend/src/components/common/ErrorAlert.tsx
@@ -1,5 +1,5 @@
-import React, { useRef } from "react";
 import { Alert, AlertTitle, Box, Typography, useTheme } from "@mui/material";
+import React, { useRef } from "react";
 
 interface ErrorAlertProps {
   title?: string;
@@ -15,12 +15,12 @@ const ErrorAlert: React.FC<ErrorAlertProps> = ({ title, message }) => {
         icon={false}
         severity="error"
         sx={{
-          color: theme.palette.Error.Light,
+          color: theme.palette.Error.Light.Default,
           width: "100%",
           height: "100%",
           borderRadius: "4px",
           border: "2px solid",
-          borderColor: theme.palette.Error.Hover,
+          borderColor: theme.palette.Error.Light.Hover,
           padding: "20px",
           display: "flex",
           flexDirection: "column",
@@ -29,11 +29,17 @@ const ErrorAlert: React.FC<ErrorAlertProps> = ({ title, message }) => {
         }}
       >
         <AlertTitle marginBottom="3px">
-          <Typography variant="titleMedium" color={theme.palette.Error.Default}>
+          <Typography
+            variant="titleMedium"
+            color={theme.palette.Error.Dark.Default}
+          >
             {title || "Error"}
           </Typography>
         </AlertTitle>
-        <Typography variant="bodyMedium" color={theme.palette.Error.Pressed}>
+        <Typography
+          variant="bodyMedium"
+          color={theme.palette.Error.Dark.Pressed}
+        >
           {message || "An error has occurred."}
         </Typography>
       </Alert>

--- a/frontend/src/components/common/MainPageButton.tsx
+++ b/frontend/src/components/common/MainPageButton.tsx
@@ -1,6 +1,6 @@
-import React from "react";
-import { Typography, Button, useTheme } from "@mui/material";
 import ChevronLeftIcon from "@mui/icons-material/ChevronLeft";
+import { Button, Typography, useTheme } from "@mui/material";
+import React from "react";
 import { useHistory } from "react-router-dom";
 import { LANDING_PAGE } from "../../constants/Routes";
 import { useUser } from "../../hooks/useUser";
@@ -17,7 +17,9 @@ const MainPageButton = (): React.ReactElement => {
         variant="text"
         onClick={navigateTo}
         startIcon={
-          <ChevronLeftIcon sx={{ color: theme.palette[user.role].Default }} />
+          <ChevronLeftIcon
+            sx={{ color: theme.palette[user.role].Dark.Default }}
+          />
         }
         sx={{
           display: "flex",
@@ -36,7 +38,7 @@ const MainPageButton = (): React.ReactElement => {
         <Typography
           variant="labelLarge"
           sx={{
-            color: theme.palette[user.role].Default,
+            color: theme.palette[user.role].Dark.Default,
           }}
         >
           Back

--- a/frontend/src/components/common/navbar/PageTabs.tsx
+++ b/frontend/src/components/common/navbar/PageTabs.tsx
@@ -1,11 +1,10 @@
-import React from "react";
-import HomeIcon from "@mui/icons-material/Home";
-import HomeOutlinedIcon from "@mui/icons-material/HomeOutlined";
 import BookmarkIcon from "@mui/icons-material/Bookmark";
 import BookmarkBorderOutlinedIcon from "@mui/icons-material/BookmarkBorderOutlined";
-import { Button, Box, useTheme } from "@mui/material";
+import HomeIcon from "@mui/icons-material/Home";
+import HomeOutlinedIcon from "@mui/icons-material/HomeOutlined";
+import { Box, Button, useTheme } from "@mui/material";
 import { useHistory, useLocation } from "react-router-dom";
-import { HOME_PAGE, BOOKMARKS_PAGE } from "../../../constants/Routes";
+import { BOOKMARKS_PAGE, HOME_PAGE } from "../../../constants/Routes";
 
 const PageTabs = () => {
   const theme = useTheme();
@@ -43,18 +42,18 @@ const PageTabs = () => {
         sx={{
           ...sharedStyle,
           backgroundColor: isHome
-            ? theme.palette.NewLearnerLight.Selected
+            ? theme.palette.Learner.Light.Selected
             : "transparent",
           color: isHome
-            ? theme.palette.NewLearnerDark.Selected
-            : theme.palette.NewLearnerDark.Default,
+            ? theme.palette.Learner.Dark.Selected
+            : theme.palette.Learner.Dark.Default,
           "&:hover": {
-            backgroundColor: theme.palette.NewLearnerLight.Hover,
-            color: theme.palette.NewLearnerDark.Hover,
+            backgroundColor: theme.palette.Learner.Light.Hover,
+            color: theme.palette.Learner.Dark.Hover,
           },
           "&:active": {
-            backgroundColor: theme.palette.Learner.Light,
-            color: theme.palette.NewLearnerDark.Pressed,
+            backgroundColor: theme.palette.Learner.Light.Default,
+            color: theme.palette.Learner.Dark.Pressed,
           },
         }}
       >
@@ -73,18 +72,18 @@ const PageTabs = () => {
         sx={{
           ...sharedStyle,
           backgroundColor: isBookmarks
-            ? theme.palette.NewLearnerLight.Selected
+            ? theme.palette.Learner.Light.Selected
             : "transparent",
           color: isBookmarks
-            ? theme.palette.NewLearnerDark.Selected
-            : theme.palette.NewLearnerDark.Default,
+            ? theme.palette.Learner.Dark.Selected
+            : theme.palette.Learner.Dark.Default,
           "&:hover": {
-            backgroundColor: theme.palette.NewLearnerLight.Hover,
-            color: theme.palette.NewLearnerDark.Hover,
+            backgroundColor: theme.palette.Learner.Light.Hover,
+            color: theme.palette.Learner.Dark.Hover,
           },
           "&:active": {
-            backgroundColor: theme.palette.NewLearnerLight.Pressed,
-            color: theme.palette.NewLearnerDark.Pressed,
+            backgroundColor: theme.palette.Learner.Light.Pressed,
+            color: theme.palette.Learner.Dark.Pressed,
           },
         }}
       >

--- a/frontend/src/components/course_viewing/modals/CreateUnitModal.tsx
+++ b/frontend/src/components/course_viewing/modals/CreateUnitModal.tsx
@@ -1,6 +1,5 @@
-import React, { useState } from "react";
-import CloseIcon from "@mui/icons-material/Close";
 import { ModeOutlined } from "@mui/icons-material";
+import CloseIcon from "@mui/icons-material/Close";
 import {
   Box,
   Button,
@@ -11,6 +10,7 @@ import {
   Typography,
   useTheme,
 } from "@mui/material";
+import { useState } from "react";
 import { useUser } from "../../../hooks/useUser";
 import StartAdornedTextField from "../../common/form/StartAdornedTextField";
 
@@ -107,7 +107,7 @@ export default function CreateUnitModal({
                   width: "100%",
                 }}
                 adornment={<ModeOutlined />}
-                focusedBorderColor={theme.palette.Administrator.Default}
+                focusedBorderColor={theme.palette.Administrator.Dark.Default}
               />
             </Box>
           </DialogContent>
@@ -129,14 +129,14 @@ export default function CreateUnitModal({
               height: "40px",
               gap: "8px",
               "&:hover": {
-                bgcolor: theme.palette[user.role].Hover,
+                bgcolor: theme.palette[user.role].Light.Hover,
               },
             }}
             onClick={handleCloseCreateUnitModal}
           >
             <Typography
               variant="labelLarge"
-              color={theme.palette[user.role].Default}
+              color={theme.palette[user.role].Dark.Default}
             >
               CANCEL
             </Typography>
@@ -147,9 +147,9 @@ export default function CreateUnitModal({
               display: "flex",
               height: "40px",
               gap: "8px",
-              backgroundColor: theme.palette[user.role].Default,
+              backgroundColor: theme.palette[user.role].Dark.Default,
               "&:hover": {
-                bgcolor: theme.palette[user.role].Default,
+                bgcolor: theme.palette[user.role].Dark.Default,
               },
             }}
             onClick={async () => {

--- a/frontend/src/components/course_viewing/modals/DeleteUnitModal.tsx
+++ b/frontend/src/components/course_viewing/modals/DeleteUnitModal.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import CloseIcon from "@mui/icons-material/Close";
 import {
   Box,
@@ -108,14 +107,14 @@ export default function CreateUnitModal(props: DeleteUnitModalProps) {
               height: "40px",
               gap: "8px",
               "&:hover": {
-                bgcolor: theme.palette[user.role].Hover,
+                bgcolor: theme.palette[user.role].Light.Hover,
               },
             }}
             onClick={handleCloseDeleteUnitModal}
           >
             <Typography
               variant="labelLarge"
-              color={theme.palette[user.role].Default}
+              color={theme.palette[user.role].Dark.Default}
             >
               GO BACK
             </Typography>
@@ -126,9 +125,9 @@ export default function CreateUnitModal(props: DeleteUnitModalProps) {
               display: "flex",
               height: "40px",
               gap: "8px",
-              backgroundColor: theme.palette.Error.Default,
+              backgroundColor: theme.palette.Error.Dark.Default,
               "&:hover": {
-                bgcolor: theme.palette.Error.Default,
+                bgcolor: theme.palette.Error.Dark.Default,
               },
             }}
             onClick={async () => {

--- a/frontend/src/components/course_viewing/modals/EditUnitModal.tsx
+++ b/frontend/src/components/course_viewing/modals/EditUnitModal.tsx
@@ -1,6 +1,5 @@
-import React, { useState } from "react";
-import CloseIcon from "@mui/icons-material/Close";
 import { ModeOutlined } from "@mui/icons-material";
+import CloseIcon from "@mui/icons-material/Close";
 import {
   Box,
   Button,
@@ -11,6 +10,7 @@ import {
   Typography,
   useTheme,
 } from "@mui/material";
+import { useState } from "react";
 import { useUser } from "../../../hooks/useUser";
 import StartAdornedTextField from "../../common/form/StartAdornedTextField";
 
@@ -110,7 +110,7 @@ export default function EditUnitModal({
                   width: "100%",
                 }}
                 adornment={<ModeOutlined />}
-                focusedBorderColor={theme.palette.Administrator.Default}
+                focusedBorderColor={theme.palette.Administrator.Dark.Default}
               />
             </Box>
           </DialogContent>
@@ -132,14 +132,14 @@ export default function EditUnitModal({
               height: "40px",
               gap: "8px",
               "&:hover": {
-                bgcolor: theme.palette[user.role].Hover,
+                bgcolor: theme.palette[user.role].Light.Hover,
               },
             }}
             onClick={handleCloseEditUnitModal}
           >
             <Typography
               variant="labelLarge"
-              color={theme.palette[user.role].Default}
+              color={theme.palette[user.role].Dark.Default}
             >
               CANCEL
             </Typography>
@@ -150,9 +150,9 @@ export default function EditUnitModal({
               display: "flex",
               height: "40px",
               gap: "8px",
-              backgroundColor: theme.palette[user.role].Default,
+              backgroundColor: theme.palette[user.role].Dark.Default,
               "&:hover": {
-                bgcolor: theme.palette[user.role].Default,
+                bgcolor: theme.palette[user.role].Dark.Default,
               },
             }}
             onClick={async () => {

--- a/frontend/src/components/course_viewing/sidebar/ContextMenu.tsx
+++ b/frontend/src/components/course_viewing/sidebar/ContextMenu.tsx
@@ -1,4 +1,6 @@
-import React from "react";
+import DeleteOutlineIcon from "@mui/icons-material/DeleteOutline";
+import EditOutlinedIcon from "@mui/icons-material/EditOutlined";
+import MoveDownIcon from "@mui/icons-material/MoveDown";
 import {
   Divider,
   ListItemIcon,
@@ -7,9 +9,6 @@ import {
   Typography,
   useTheme,
 } from "@mui/material";
-import EditOutlinedIcon from "@mui/icons-material/EditOutlined";
-import DeleteOutlineIcon from "@mui/icons-material/DeleteOutline";
-import MoveDownIcon from "@mui/icons-material/MoveDown";
 import { UnitSidebarModalType } from "../../../types/CourseTypes";
 
 interface ContextMenuProps {
@@ -76,13 +75,13 @@ const ContextMenu = ({ anchorEl, onClose, onModalOpen }: ContextMenuProps) => {
         <ListItemIcon>
           <DeleteOutlineIcon
             fontSize="small"
-            htmlColor={theme.palette.Error.Default}
+            htmlColor={theme.palette.Error.Dark.Default}
           />
         </ListItemIcon>
         <Typography
           variant="bodyMedium"
           noWrap
-          color={theme.palette.Error.Default}
+          color={theme.palette.Error.Dark.Default}
         >
           Delete
         </Typography>

--- a/frontend/src/components/course_viewing/sidebar/UnitSidebar.tsx
+++ b/frontend/src/components/course_viewing/sidebar/UnitSidebar.tsx
@@ -1,4 +1,6 @@
-import React, { useEffect, useState } from "react";
+import AddIcon from "@mui/icons-material/Add";
+import MenuOpenIcon from "@mui/icons-material/MenuOpen";
+import MoreVertIcon from "@mui/icons-material/MoreVert";
 import {
   Box,
   Button,
@@ -11,16 +13,14 @@ import {
   Typography,
   useTheme,
 } from "@mui/material";
-import MoreVertIcon from "@mui/icons-material/MoreVert";
-import MenuOpenIcon from "@mui/icons-material/MenuOpen";
-import AddIcon from "@mui/icons-material/Add";
-import { CourseUnit, UnitSidebarModalType } from "../../../types/CourseTypes";
+import React, { useEffect, useState } from "react";
+import CourseAPIClient from "../../../APIClients/CourseAPIClient";
 import { useUser } from "../../../hooks/useUser";
+import { CourseUnit, UnitSidebarModalType } from "../../../types/CourseTypes";
 import { isAdministrator } from "../../../types/UserTypes";
 import CreateUnitModal from "../modals/CreateUnitModal";
-import EditUnitModal from "../modals/EditUnitModal";
 import DeleteUnitModal from "../modals/DeleteUnitModal";
-import CourseAPIClient from "../../../APIClients/CourseAPIClient";
+import EditUnitModal from "../modals/EditUnitModal";
 import ContextMenu from "./ContextMenu";
 
 interface UnitSideBarProps {
@@ -169,7 +169,7 @@ export default function UnitSidebar({
       <Box
         height="100vh"
         sx={{
-          backgroundColor: theme.palette[user.role].Light,
+          backgroundColor: theme.palette[user.role].Light.Default,
           overflowX: "hidden",
         }}
       >
@@ -224,10 +224,10 @@ export default function UnitSidebar({
                     px: "32px",
                     backgroundColor:
                       selectedIndex === index
-                        ? theme.palette[user.role].Hover
+                        ? theme.palette[user.role].Dark.Hover
                         : "transparent",
                     "&:hover": {
-                      backgroundColor: theme.palette[user.role].Hover,
+                      backgroundColor: theme.palette[user.role].Dark.Hover,
                     },
                   }}
                   onClick={(event) => handleListItemClick(event, index)}
@@ -268,7 +268,7 @@ export default function UnitSidebar({
               width: "100%",
               height: "40px",
               maxWidth: "236px",
-              backgroundColor: theme.palette[user.role].Default,
+              backgroundColor: theme.palette[user.role].Dark.Default,
               alignItems: "center",
               marginTop: "24px",
               marginBottom: "24px",

--- a/frontend/src/components/help/CreatePasswordHelpConfirmationModal.tsx
+++ b/frontend/src/components/help/CreatePasswordHelpConfirmationModal.tsx
@@ -1,15 +1,15 @@
-import React from "react";
-import {
-  Dialog,
-  Container,
-  Typography,
-  Button,
-  IconButton,
-  useTheme,
-  Box,
-} from "@mui/material";
 import CheckCircleIcon from "@mui/icons-material/CheckCircle";
 import CloseIcon from "@mui/icons-material/Close";
+import {
+  Box,
+  Button,
+  Container,
+  Dialog,
+  IconButton,
+  Typography,
+  useTheme,
+} from "@mui/material";
+import React from "react";
 
 interface CreatePasswordHelpConfirmationModalProps {
   open: boolean;
@@ -155,9 +155,9 @@ const CreatePasswordHelpConfirmationModal: React.FC<
             lineHeight: theme.typography.labelLarge.lineHeight,
             letterSpacing: theme.typography.labelLarge.letterSpacing,
             color: theme.palette.Neutral[100],
-            backgroundColor: theme.palette.Learner.Default,
+            backgroundColor: theme.palette.Learner.Dark.Default,
             "&:hover": {
-              background: theme.palette.Learner.Pressed,
+              background: theme.palette.Learner.Dark.Pressed,
             },
           }}
         >

--- a/frontend/src/components/help/CreatePasswordHelpModal.tsx
+++ b/frontend/src/components/help/CreatePasswordHelpModal.tsx
@@ -1,14 +1,14 @@
-import React, { useState } from "react";
 import {
+  Box,
+  Button,
   Dialog,
   DialogContent,
+  IconButton,
   TextField,
   Typography,
-  Button,
-  Box,
   useTheme,
-  IconButton,
 } from "@mui/material";
+import React, { useState } from "react";
 
 import CloseIcon from "@mui/icons-material/Close";
 import CreatePasswordHelpConfirmationModal from "./CreatePasswordHelpConfirmationModal";
@@ -151,7 +151,7 @@ const CreatePasswordHelpModal: React.FC<CreatePasswordHelpModalProps> = ({
             variant="text"
             onClick={onClose}
             sx={{
-              color: theme.palette.Learner.Default,
+              color: theme.palette.Learner.Dark.Default,
               textAlign: "left",
               fontSize: theme.typography.bodyMedium.fontSize,
               fontWeight: theme.typography.bodySmall.fontWeight,
@@ -189,9 +189,9 @@ const CreatePasswordHelpModal: React.FC<CreatePasswordHelpModalProps> = ({
               lineHeight: theme.typography.labelLarge.lineHeight,
               letterSpacing: theme.typography.labelLarge.letterSpacing,
               color: theme.palette.Neutral[100],
-              backgroundColor: theme.palette.Learner.Default,
+              backgroundColor: theme.palette.Learner.Dark.Default,
               "&:hover": {
-                background: theme.palette.Learner.Pressed,
+                background: theme.palette.Learner.Dark.Pressed,
               },
             }}
           >

--- a/frontend/src/components/help/modal/ConfirmationScreen.tsx
+++ b/frontend/src/components/help/modal/ConfirmationScreen.tsx
@@ -1,14 +1,14 @@
-import React from "react";
-import {
-  Dialog,
-  Typography,
-  Box,
-  IconButton,
-  useTheme,
-  Button,
-} from "@mui/material";
 import CloseIcon from "@mui/icons-material/Close";
-import { NeedHelpModalProps, ModalHandlers } from "./types";
+import {
+  Box,
+  Button,
+  Dialog,
+  IconButton,
+  Typography,
+  useTheme,
+} from "@mui/material";
+import React from "react";
+import { ModalHandlers, NeedHelpModalProps } from "./types";
 
 interface ConfirmationScreenProps extends NeedHelpModalProps {
   handlers: ModalHandlers;
@@ -139,7 +139,7 @@ const ConfirmationScreen: React.FC<ConfirmationScreenProps> = ({
             handlers.handleBackToHome();
           }}
           sx={{
-            color: theme.palette.Learner.Default,
+            color: theme.palette.Learner.Dark.Default,
             textAlign: "center",
             cursor: "pointer",
             "&:hover": {
@@ -163,12 +163,12 @@ const ConfirmationScreen: React.FC<ConfirmationScreenProps> = ({
             alignItems: "center",
             gap: "8px",
             borderRadius: "4px",
-            background: theme.palette.Learner.Default,
+            background: theme.palette.Learner.Dark.Default,
             padding: "10px 24px",
             minWidth: "auto",
             width: "auto",
             "&:hover": {
-              background: theme.palette.Learner.Pressed,
+              background: theme.palette.Learner.Dark.Pressed,
             },
           }}
         >

--- a/frontend/src/components/help/modal/ConfirmationScreenContent.tsx
+++ b/frontend/src/components/help/modal/ConfirmationScreenContent.tsx
@@ -1,6 +1,6 @@
-import React from "react";
-import { Typography, Box, Button } from "@mui/material";
+import { Box, Button, Typography } from "@mui/material";
 import { Theme } from "@mui/material/styles";
+import React from "react";
 
 interface ConfirmationScreenContentProps {
   handleBackToHome: () => void;
@@ -109,7 +109,7 @@ const ConfirmationScreenContent: React.FC<ConfirmationScreenContentProps> = ({
             handleBackToHome();
           }}
           sx={{
-            color: theme.palette.Learner.Default,
+            color: theme.palette.Learner.Dark.Default,
             cursor: "pointer",
             "&:hover": {
               opacity: 0.8,
@@ -132,12 +132,12 @@ const ConfirmationScreenContent: React.FC<ConfirmationScreenContentProps> = ({
             alignItems: "center",
             gap: "8px",
             borderRadius: "4px",
-            background: theme.palette.Learner.Default,
+            background: theme.palette.Learner.Dark.Default,
             padding: "10px 24px",
             minWidth: "auto",
             width: "auto",
             "&:hover": {
-              background: theme.palette.Learner.Pressed,
+              background: theme.palette.Learner.Dark.Pressed,
             },
           }}
         >

--- a/frontend/src/components/help/modal/ContentScreenContent.tsx
+++ b/frontend/src/components/help/modal/ContentScreenContent.tsx
@@ -1,6 +1,6 @@
-import React from "react";
-import { Typography, Box, TextField, Button } from "@mui/material";
+import { Box, Button, TextField, Typography } from "@mui/material";
 import { Theme } from "@mui/material/styles";
+import React from "react";
 
 interface ContentScreenContentProps {
   handleBackToHome: () => void;
@@ -80,7 +80,7 @@ const ContentScreenContent: React.FC<ContentScreenContentProps> = ({
               borderColor: theme.palette.Neutral[500],
             },
             "&.Mui-focused .MuiOutlinedInput-notchedOutline": {
-              borderColor: theme.palette.Learner.Default,
+              borderColor: theme.palette.Learner.Dark.Default,
               borderWidth: "2px",
             },
           },
@@ -110,7 +110,7 @@ const ContentScreenContent: React.FC<ContentScreenContentProps> = ({
           variant="labelMedium"
           onClick={handleBackToHome}
           sx={{
-            color: theme.palette.Learner.Default,
+            color: theme.palette.Learner.Dark.Default,
             cursor: "pointer",
             "&:hover": {
               opacity: 0.8,
@@ -131,12 +131,12 @@ const ContentScreenContent: React.FC<ContentScreenContentProps> = ({
             alignItems: "center",
             gap: "8px",
             borderRadius: "4px",
-            background: theme.palette.Learner.Default,
+            background: theme.palette.Learner.Dark.Default,
             padding: "10px 24px",
             minWidth: "auto",
             width: "auto",
             "&:hover": {
-              background: theme.palette.Learner.Pressed,
+              background: theme.palette.Learner.Dark.Pressed,
             },
             "&:disabled": {
               background: theme.palette.Neutral[400],

--- a/frontend/src/components/help/modal/ErrorScreenContent.tsx
+++ b/frontend/src/components/help/modal/ErrorScreenContent.tsx
@@ -1,6 +1,6 @@
-import React from "react";
-import { Typography, Box, Button } from "@mui/material";
+import { Box, Button, Typography } from "@mui/material";
 import { Theme } from "@mui/material/styles";
+import React from "react";
 
 interface ErrorScreenContentProps {
   handleBackToContent: () => void;
@@ -66,12 +66,12 @@ const ErrorScreenContent: React.FC<ErrorScreenContentProps> = ({
             alignItems: "center",
             gap: "8px",
             borderRadius: "4px",
-            background: theme.palette.Learner.Default,
+            background: theme.palette.Learner.Dark.Default,
             padding: "10px 24px",
             minWidth: "auto",
             width: "auto",
             "&:hover": {
-              background: theme.palette.Learner.Pressed,
+              background: theme.palette.Learner.Dark.Pressed,
             },
           }}
         >

--- a/frontend/src/components/help/modal/HomeScreenContent.tsx
+++ b/frontend/src/components/help/modal/HomeScreenContent.tsx
@@ -1,6 +1,6 @@
-import React from "react";
-import { DialogContent, Typography, Box } from "@mui/material";
+import { Box, DialogContent, Typography } from "@mui/material";
 import { Theme } from "@mui/material/styles";
+import React from "react";
 
 interface HomeScreenContentProps {
   handleContentClick: () => void;
@@ -55,11 +55,11 @@ const HomeScreenContent: React.FC<HomeScreenContentProps> = ({
               gap: "8px",
               alignSelf: "stretch",
               borderRadius: "4px",
-              border: `1px dashed ${theme.palette.Learner.Default}`,
-              background: theme.palette.Learner.Light,
+              border: `1px dashed ${theme.palette.Learner.Dark.Default}`,
+              background: theme.palette.Learner.Light.Default,
               cursor: "pointer",
               "&:hover": {
-                background: theme.palette.Learner.Hover,
+                background: theme.palette.Learner.Light.Hover,
               },
               minHeight: "fit-content",
             }}
@@ -68,7 +68,7 @@ const HomeScreenContent: React.FC<HomeScreenContentProps> = ({
               variant="bodySmall"
               sx={{
                 alignSelf: "stretch",
-                color: theme.palette.Learner.Default,
+                color: theme.palette.Learner.Dark.Default,
               }}
             >
               Help me with
@@ -77,7 +77,7 @@ const HomeScreenContent: React.FC<HomeScreenContentProps> = ({
               variant="headlineMedium"
               sx={{
                 alignSelf: "stretch",
-                color: theme.palette.Learner.Default,
+                color: theme.palette.Learner.Dark.Default,
               }}
             >
               Content
@@ -105,11 +105,11 @@ const HomeScreenContent: React.FC<HomeScreenContentProps> = ({
               gap: "8px",
               alignSelf: "stretch",
               borderRadius: "4px",
-              border: `1px dashed ${theme.palette.Learner.Default}`,
-              background: theme.palette.Learner.Light,
+              border: `1px dashed ${theme.palette.Learner.Dark.Default}`,
+              background: theme.palette.Learner.Light.Default,
               cursor: "pointer",
               "&:hover": {
-                background: theme.palette.Learner.Hover,
+                background: theme.palette.Learner.Light.Hover,
               },
               minHeight: "fit-content",
             }}
@@ -118,7 +118,7 @@ const HomeScreenContent: React.FC<HomeScreenContentProps> = ({
               variant="bodySmall"
               sx={{
                 alignSelf: "stretch",
-                color: theme.palette.Learner.Default,
+                color: theme.palette.Learner.Dark.Default,
               }}
             >
               Help me with
@@ -127,7 +127,7 @@ const HomeScreenContent: React.FC<HomeScreenContentProps> = ({
               variant="headlineMedium"
               sx={{
                 alignSelf: "stretch",
-                color: theme.palette.Learner.Default,
+                color: theme.palette.Learner.Dark.Default,
               }}
             >
               Navigating

--- a/frontend/src/components/profile/ChangePasswordModal.tsx
+++ b/frontend/src/components/profile/ChangePasswordModal.tsx
@@ -1,13 +1,13 @@
-import React, { useState } from "react";
+import CloseIcon from "@mui/icons-material/Close";
 import {
+  Box,
+  Button,
   Dialog,
   IconButton,
   Typography,
-  Button,
   useTheme,
-  Box,
 } from "@mui/material";
-import CloseIcon from "@mui/icons-material/Close";
+import React, { useState } from "react";
 import { useUser } from "../../hooks/useUser";
 import PasswordCheck from "../auth/PasswordCheck";
 
@@ -130,7 +130,7 @@ const ChangePasswordModal: React.FC<ChangePasswordModalProps> = ({
                 fontWeight: "300",
                 lineHeight: "120%",
                 letterSpacing: "0.7px",
-                color: theme.palette[`${user.role}`].Default,
+                color: theme.palette[`${user.role}`].Dark.Default,
               }}
             >
               Cancel
@@ -150,11 +150,11 @@ const ChangePasswordModal: React.FC<ChangePasswordModalProps> = ({
               alignSelf: "stretch",
               borderRadius: "4px",
               backgroundColor: isFormValid
-                ? theme.palette[`${user.role}`].Default
+                ? theme.palette[`${user.role}`].Dark.Default
                 : "#ccc",
               "&:hover": {
                 background: isFormValid
-                  ? theme.palette[`${user.role}`].Pressed
+                  ? theme.palette[`${user.role}`].Dark.Pressed
                   : "#ccc",
               },
               padding: "10px 24px",

--- a/frontend/src/components/profile/EditDetailsModal.tsx
+++ b/frontend/src/components/profile/EditDetailsModal.tsx
@@ -1,14 +1,14 @@
-import React, { useState } from "react";
+import CloseIcon from "@mui/icons-material/Close";
 import {
+  Box,
+  Button,
   Dialog,
   IconButton,
-  Typography,
-  Button,
   TextField,
+  Typography,
   useTheme,
-  Box,
 } from "@mui/material";
-import CloseIcon from "@mui/icons-material/Close";
+import React, { useState } from "react";
 import { useUser } from "../../hooks/useUser";
 import { isAuthenticatedFacilitator } from "../../types/AuthTypes";
 import CharacterLimitTextField from "../common/form/CharacterLimitTextField";
@@ -176,7 +176,7 @@ const EditDetailsModal: React.FC<EditDetailsModalProps> = ({
           <Typography
             variant="labelLarge"
             sx={{
-              color: theme.palette[user.role].Default,
+              color: theme.palette[user.role].Dark.Default,
             }}
           >
             Cancel
@@ -192,9 +192,9 @@ const EditDetailsModal: React.FC<EditDetailsModalProps> = ({
             alignItems: "center",
             gap: "8px",
             borderRadius: "4px",
-            backgroundColor: theme.palette[user.role].Default,
+            backgroundColor: theme.palette[user.role].Dark.Default,
             "&:hover": {
-              background: theme.palette[user.role].Pressed,
+              background: theme.palette[user.role].Dark.Pressed,
             },
             padding: "10px 24px",
           }}

--- a/frontend/src/components/profile/MyAccountPage.tsx
+++ b/frontend/src/components/profile/MyAccountPage.tsx
@@ -1,17 +1,17 @@
-import React, { useState, useContext } from "react";
-import { Container, Typography, Button, useTheme } from "@mui/material";
-import PasswordIcon from "@mui/icons-material/Password";
 import ModeEditOutlineOutlinedIcon from "@mui/icons-material/ModeEditOutlineOutlined";
-import MainPageButton from "../common/MainPageButton";
-import ProfilePicture from "./ProfilePicture";
-import EditDetailsModal from "./EditDetailsModal";
-import ChangePasswordModal from "./ChangePasswordModal";
-import AuthContext from "../../contexts/AuthContext";
-import userAPIClient from "../../APIClients/UserAPIClient";
+import PasswordIcon from "@mui/icons-material/Password";
+import { Button, Container, Typography, useTheme } from "@mui/material";
+import React, { useContext, useState } from "react";
 import authAPIClient from "../../APIClients/AuthAPIClient";
+import userAPIClient from "../../APIClients/UserAPIClient";
+import AuthContext from "../../contexts/AuthContext";
 import { isAuthenticatedFacilitator } from "../../types/AuthTypes";
 import { isFacilitator } from "../../types/UserTypes";
+import MainPageButton from "../common/MainPageButton";
 import UploadProfilePictureModal from "../user_management/UploadProfilePictureModal";
+import ChangePasswordModal from "./ChangePasswordModal";
+import EditDetailsModal from "./EditDetailsModal";
+import ProfilePicture from "./ProfilePicture";
 
 const MyAccount = (): React.ReactElement => {
   const theme = useTheme();
@@ -254,9 +254,10 @@ const MyAccount = (): React.ReactElement => {
                   alignSelf: "stretch",
                   borderRadius: "4px",
                   backgroundColor:
-                    theme.palette[authenticatedUser.role].Default,
+                    theme.palette[authenticatedUser.role].Dark.Default,
                   "&:hover": {
-                    background: theme.palette[authenticatedUser.role].Pressed,
+                    background:
+                      theme.palette[authenticatedUser.role].Dark.Pressed,
                   },
                   padding: "10px 24px 10px 16px",
                   flex: "1 0 0",
@@ -295,9 +296,9 @@ const MyAccount = (): React.ReactElement => {
                   gap: "8px",
                   alignSelf: "stretch",
                   borderRadius: "4px",
-                  backgroundColor: theme.palette.Error.Light,
+                  backgroundColor: theme.palette.Error.Light.Default,
                   "&:hover": {
-                    background: theme.palette.Error.Hover,
+                    background: theme.palette.Error.Light.Hover,
                   },
                   padding: "10px 24px 10px 16px",
                   flex: "1 0 0",
@@ -314,10 +315,12 @@ const MyAccount = (): React.ReactElement => {
                     alignSelf: "stretch",
                   }}
                 >
-                  <PasswordIcon sx={{ color: theme.palette.Error.Default }} />
+                  <PasswordIcon
+                    sx={{ color: theme.palette.Error.Dark.Default }}
+                  />
                   <Typography
                     variant="labelLarge"
-                    sx={{ color: theme.palette.Error.Default }}
+                    sx={{ color: theme.palette.Error.Dark.Default }}
                   >
                     Change Password
                   </Typography>

--- a/frontend/src/components/profile/ProfilePicture.tsx
+++ b/frontend/src/components/profile/ProfilePicture.tsx
@@ -1,7 +1,7 @@
-import React, { Dispatch, SetStateAction } from "react";
-import { Box, Typography, Avatar } from "@mui/material";
-import { useTheme } from "@mui/material/styles";
 import { CameraAlt } from "@mui/icons-material";
+import { Avatar, Box, Typography } from "@mui/material";
+import { useTheme } from "@mui/material/styles";
+import React, { Dispatch, SetStateAction } from "react";
 import { useUser } from "../../hooks/useUser";
 
 interface ProfilePictureProps {
@@ -38,7 +38,7 @@ const ProfilePicture = ({
         sx={{
           width: "100%",
           height: "100%",
-          bgcolor: theme.palette[user.role].Hover,
+          bgcolor: theme.palette[user.role].Light.Hover,
           "&:hover": {
             backgroundColor: "rgba(0, 0, 0, 0.6)",
 
@@ -55,7 +55,7 @@ const ProfilePicture = ({
       >
         <Typography
           sx={{
-            color: theme.palette[user.role].Default,
+            color: theme.palette[user.role].Dark.Default,
             fontSize: 0.375 * size,
             fontWeight: 400,
             lineHeight: "140%",

--- a/frontend/src/components/user_management/AddAdminModal.tsx
+++ b/frontend/src/components/user_management/AddAdminModal.tsx
@@ -1,16 +1,16 @@
-import React from "react";
-import {
-  Dialog,
-  DialogTitle,
-  DialogContent,
-  Box,
-  Typography,
-  Button,
-  IconButton,
-} from "@mui/material";
-import { PersonOutlineOutlined, AlternateEmail } from "@mui/icons-material";
+import { AlternateEmail, PersonOutlineOutlined } from "@mui/icons-material";
 import CloseIcon from "@mui/icons-material/Close";
+import {
+  Box,
+  Button,
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  IconButton,
+  Typography,
+} from "@mui/material";
 import { useTheme } from "@mui/material/styles";
+import React from "react";
 import StartAdornedTextField from "../common/form/StartAdornedTextField";
 
 interface AddAdminModalProps {
@@ -140,14 +140,14 @@ const AddAdminModal: React.FC<AddAdminModalProps> = ({
               display: "flex",
               height: "40px",
               gap: "8px",
-              "&:hover": { bgcolor: theme.palette.Administrator.Hover },
+              "&:hover": { bgcolor: theme.palette.Administrator.Light.Hover },
               borderColor: theme.palette.Neutral[500],
             }}
             onClick={onClose}
           >
             <Typography
               variant="labelLarge"
-              color={theme.palette.Administrator.Default}
+              color={theme.palette.Administrator.Dark.Default}
             >
               CANCEL
             </Typography>
@@ -158,8 +158,8 @@ const AddAdminModal: React.FC<AddAdminModalProps> = ({
               display: "flex",
               height: "40px",
               gap: "8px",
-              backgroundColor: theme.palette.Administrator.Default,
-              "&:hover": { bgcolor: theme.palette.Administrator.Default },
+              backgroundColor: theme.palette.Administrator.Dark.Default,
+              "&:hover": { bgcolor: theme.palette.Administrator.Dark.Default },
             }}
             onClick={handleAddAdmin}
           >

--- a/frontend/src/components/user_management/DeleteUserModal.tsx
+++ b/frontend/src/components/user_management/DeleteUserModal.tsx
@@ -1,16 +1,16 @@
-import React from "react";
+import CloseIcon from "@mui/icons-material/Close";
 import {
+  Box,
+  Button,
   Dialog,
-  DialogTitle,
   DialogContent,
   DialogContentText,
-  Box,
-  Typography,
-  Button,
+  DialogTitle,
   IconButton,
+  Typography,
 } from "@mui/material";
-import CloseIcon from "@mui/icons-material/Close";
 import { useTheme } from "@mui/material/styles";
+import React from "react";
 
 interface DeleteUserModalProps {
   open: boolean;
@@ -89,14 +89,14 @@ const DeleteUserModal: React.FC<DeleteUserModalProps> = ({
             display: "flex",
             height: "40px",
             gap: "8px",
-            "&:hover": { bgcolor: theme.palette.Administrator.Hover },
+            "&:hover": { bgcolor: theme.palette.Administrator.Light.Hover },
             borderColor: theme.palette.Neutral[500],
           }}
           onClick={onClose}
         >
           <Typography
             variant="labelLarge"
-            color={theme.palette.Administrator.Default}
+            color={theme.palette.Administrator.Dark.Default}
           >
             GO BACK
           </Typography>
@@ -107,8 +107,8 @@ const DeleteUserModal: React.FC<DeleteUserModalProps> = ({
             display: "flex",
             height: "40px",
             gap: "8px",
-            backgroundColor: theme.palette.Error.Default,
-            "&:hover": { bgcolor: theme.palette.Error.Default },
+            backgroundColor: theme.palette.Error.Dark.Default,
+            "&:hover": { bgcolor: theme.palette.Error.Dark.Default },
           }}
           onClick={() =>
             handleDeleteUser(deleteUserId, deleteFirstName, deleteLastName)

--- a/frontend/src/components/user_management/ManageUserPage.tsx
+++ b/frontend/src/components/user_management/ManageUserPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import PersonOutlineIcon from "@mui/icons-material/PersonOutline";
 import {
   Box,
   Button,
@@ -8,17 +8,17 @@ import {
   Typography,
   useTheme,
 } from "@mui/material";
-import PersonOutlineIcon from "@mui/icons-material/PersonOutline";
+import React, { useEffect, useState } from "react";
 
 import UserAPIClient from "../../APIClients/UserAPIClient";
 import { User } from "../../types/UserTypes";
 
-import TopToolBar from "./TopToolBar";
-import UserTable from "./UserTable";
-import AddAdminModal from "./AddAdminModal";
-import DeleteUserModal from "./DeleteUserModal";
 import AuthAPIClient from "../../APIClients/AuthAPIClient";
 import { isCaseInsensitiveSubstring } from "../../utils/StringUtils";
+import AddAdminModal from "./AddAdminModal";
+import DeleteUserModal from "./DeleteUserModal";
+import TopToolBar from "./TopToolBar";
+import UserTable from "./UserTable";
 
 const ManageUserPage = (): React.ReactElement => {
   // Main state
@@ -151,7 +151,7 @@ const ManageUserPage = (): React.ReactElement => {
         size="small"
         onClick={handleCloseAddAdminSnackbar}
         sx={{
-          color: theme.palette.Learner.Default,
+          color: theme.palette.Learner.Dark.Default,
         }}
       >
         UNDO
@@ -164,7 +164,7 @@ const ManageUserPage = (): React.ReactElement => {
         size="small"
         onClick={handleCloseDeleteUserSnackbar}
         sx={{
-          color: theme.palette.Learner.Default,
+          color: theme.palette.Learner.Dark.Default,
         }}
       >
         UNDO
@@ -187,7 +187,7 @@ const ManageUserPage = (): React.ReactElement => {
       >
         <SnackbarContent
           sx={{
-            backgroundColor: theme.palette.Success.Hover,
+            backgroundColor: theme.palette.Success.Light.Hover,
             color: theme.palette.Neutral[700],
             paddingTop: "12px",
             paddingLeft: "32px",
@@ -205,13 +205,13 @@ const ManageUserPage = (): React.ReactElement => {
             >
               <PersonOutlineIcon
                 sx={{
-                  color: theme.palette.Success.Default,
+                  color: theme.palette.Success.Dark.Default,
                 }}
               />
               <Typography
                 variant="bodyMedium"
                 sx={{
-                  color: theme.palette.Success.Default,
+                  color: theme.palette.Success.Dark.Default,
                 }}
               >
                 &quot;{addSnackbarName}&quot; was added as admin
@@ -234,7 +234,7 @@ const ManageUserPage = (): React.ReactElement => {
       >
         <SnackbarContent
           sx={{
-            backgroundColor: theme.palette.Error.Hover,
+            backgroundColor: theme.palette.Error.Light.Hover,
             color: theme.palette.Neutral[700],
             paddingTop: "12px",
             paddingLeft: "32px",
@@ -253,13 +253,13 @@ const ManageUserPage = (): React.ReactElement => {
             >
               <PersonOutlineIcon
                 sx={{
-                  color: theme.palette.Error.Default,
+                  color: theme.palette.Error.Dark.Default,
                 }}
               />
               <Typography
                 variant="bodyMedium"
                 sx={{
-                  color: theme.palette.Error.Default,
+                  color: theme.palette.Error.Dark.Default,
                 }}
               >
                 &quot;{deleteSnackbarName}&quot; was deleted from the user list

--- a/frontend/src/components/user_management/TopToolBar.tsx
+++ b/frontend/src/components/user_management/TopToolBar.tsx
@@ -1,10 +1,10 @@
-import React, { useState } from "react";
-import { Box, MenuItem, Typography, Button, Stack } from "@mui/material";
-import { Search, FilterList, Add } from "@mui/icons-material";
+import { Add, FilterList, Search } from "@mui/icons-material";
+import { Box, Button, MenuItem, Stack, Typography } from "@mui/material";
 import { useTheme } from "@mui/material/styles";
-import StartAdornedTextField from "../common/form/StartAdornedTextField";
-import { isRole } from "../../types/UserTypes";
+import React, { useState } from "react";
 import { useUser } from "../../hooks/useUser";
+import { isRole } from "../../types/UserTypes";
+import StartAdornedTextField from "../common/form/StartAdornedTextField";
 
 interface TopToolBarProps {
   searchQuery: string;
@@ -59,14 +59,14 @@ const TopToolBar: React.FC<TopToolBarProps> = ({
               }}
             />
           }
-          focusedBorderColor={theme.palette[role].Default}
+          focusedBorderColor={theme.palette[role].Dark.Default}
           sx={{
             minWidth: "400px",
             borderRadius: "8px",
             "& .MuiOutlinedInput-root": {
               "& fieldset": {
                 borderColor: isSearchActive
-                  ? theme.palette[role].Default
+                  ? theme.palette[role].Dark.Default
                   : theme.palette.Neutral[500],
               },
               "&:hover fieldset": {
@@ -91,7 +91,7 @@ const TopToolBar: React.FC<TopToolBarProps> = ({
               <FilterList sx={{ color: theme.palette.Neutral[500] }} />
             </Box>
           }
-          focusedBorderColor={theme.palette[role].Default}
+          focusedBorderColor={theme.palette[role].Dark.Default}
           sx={{
             width: "250px",
             textTransform: "uppercase",
@@ -118,10 +118,10 @@ const TopToolBar: React.FC<TopToolBarProps> = ({
                   sx={{
                     display: "inline-block",
                     color: isRole(roleOption)
-                      ? theme.palette[roleOption].Default
+                      ? theme.palette[roleOption].Dark.Default
                       : undefined,
                     backgroundColor: isRole(roleOption)
-                      ? theme.palette[roleOption].Light
+                      ? theme.palette[roleOption].Light.Default
                       : undefined,
                     padding: "4px 8px",
                     borderRadius: "8px",
@@ -137,11 +137,11 @@ const TopToolBar: React.FC<TopToolBarProps> = ({
           variant="contained"
           startIcon={<Add />}
           sx={{
-            backgroundColor: theme.palette.Administrator.Default,
+            backgroundColor: theme.palette.Administrator.Dark.Default,
             height: "56px",
             color: "white",
             "&:hover": {
-              backgroundColor: theme.palette.Administrator.Default,
+              backgroundColor: theme.palette.Administrator.Dark.Default,
             },
           }}
           onClick={handleOpenAddAdminModal}

--- a/frontend/src/components/user_management/UploadProfilePictureModal.tsx
+++ b/frontend/src/components/user_management/UploadProfilePictureModal.tsx
@@ -1,21 +1,21 @@
-import React, {
-  ChangeEvent,
-  useContext,
-  Dispatch,
-  SetStateAction,
-} from "react";
-import { Redirect } from "react-router-dom";
-import { Box, Typography, IconButton, useTheme, Dialog } from "@mui/material";
 import CloseIcon from "@mui/icons-material/Close";
 import FileUploadOutlinedIcon from "@mui/icons-material/FileUploadOutlined";
-import Divider from "@mui/material/Divider";
+import { Box, Dialog, IconButton, Typography, useTheme } from "@mui/material";
 import Button from "@mui/material/Button";
+import Divider from "@mui/material/Divider";
 import { VisuallyHidden } from "@reach/visually-hidden";
-import AuthContext from "../../contexts/AuthContext";
+import React, {
+  ChangeEvent,
+  Dispatch,
+  SetStateAction,
+  useContext,
+} from "react";
+import { Redirect } from "react-router-dom";
 import UserAPIClient from "../../APIClients/UserAPIClient";
-import { getLocalStorageObjProperty } from "../../utils/LocalStorageUtils";
 import AUTHENTICATED_USER_KEY from "../../constants/AuthConstants";
 import { HOME_PAGE } from "../../constants/Routes";
+import AuthContext from "../../contexts/AuthContext";
+import { getLocalStorageObjProperty } from "../../utils/LocalStorageUtils";
 
 interface UploadProfilePictureModalProps {
   open: boolean;
@@ -117,7 +117,7 @@ const UploadProfilePictureModal = ({
         style={{
           width: "100%",
           height: "auto",
-          backgroundImage: `repeating-linear-gradient(0deg, ${theme.palette[role].Default}, ${theme.palette[role].Default} 12px, transparent 12px, transparent 19px, ${theme.palette[role].Default} 19px), repeating-linear-gradient(90deg, ${theme.palette[role].Default}, ${theme.palette[role].Default} 12px, transparent 12px, transparent 19px, ${theme.palette[role].Default} 19px), repeating-linear-gradient(180deg, ${theme.palette[role].Default}, ${theme.palette[role].Default} 12px, transparent 12px, transparent 19px, ${theme.palette[role].Default} 19px), repeating-linear-gradient(270deg, ${theme.palette[role].Default}, ${theme.palette[role].Default} 12px, transparent 12px, transparent 19px, ${theme.palette[role].Default} 19px)`,
+          backgroundImage: `repeating-linear-gradient(0deg, ${theme.palette[role].Dark.Default}, ${theme.palette[role].Dark.Default} 12px, transparent 12px, transparent 19px, ${theme.palette[role].Dark.Default} 19px), repeating-linear-gradient(90deg, ${theme.palette[role].Dark.Default}, ${theme.palette[role].Dark.Default} 12px, transparent 12px, transparent 19px, ${theme.palette[role].Dark.Default} 19px), repeating-linear-gradient(180deg, ${theme.palette[role].Dark.Default}, ${theme.palette[role].Dark.Default} 12px, transparent 12px, transparent 19px, ${theme.palette[role].Dark.Default} 19px), repeating-linear-gradient(270deg, ${theme.palette[role].Dark.Default}, ${theme.palette[role].Dark.Default} 12px, transparent 12px, transparent 19px, ${theme.palette[role].Dark.Default} 19px)`,
           backgroundSize: "1px 100%, 100% 1px, 1px 100% , 100% 1px",
           backgroundPosition: "0 0, 0 0, calc(100% - 1px) 0, 0 100%",
           backgroundRepeat: "no-repeat",
@@ -131,7 +131,7 @@ const UploadProfilePictureModal = ({
           paddingRight: "100px",
           gap: "16px",
           borderRadius: "4px",
-          backgroundColor: theme.palette[role].Light,
+          backgroundColor: theme.palette[role].Light.Default,
         }}
         onDragOver={handleDragOver}
         onDrop={handleDrop}
@@ -153,13 +153,13 @@ const UploadProfilePictureModal = ({
         </VisuallyHidden>
       </Box>
 
-      <Box sx={{ width: "100%", color: theme.palette[role].Default }}>
+      <Box sx={{ width: "100%", color: theme.palette[role].Dark.Default }}>
         <Divider
           sx={{
             my: 1,
-            borderBlockColor: theme.palette[role].Hover,
+            borderBlockColor: theme.palette[role].Light.Hover,
             "&::before, &::after": {
-              borderColor: theme.palette[role].Hover, // Ensures both lines are the same color
+              borderColor: theme.palette[role].Light.Hover, // Ensures both lines are the same color
             },
             margin: "0px",
           }}
@@ -171,8 +171,8 @@ const UploadProfilePictureModal = ({
         <Button
           sx={{
             width: "100%",
-            background: theme.palette[role].Default,
-            "&:hover": { background: theme.palette[role].Pressed },
+            background: theme.palette[role].Dark.Default,
+            "&:hover": { background: theme.palette[role].Dark.Pressed },
           }}
           variant="contained"
           startIcon={<FileUploadOutlinedIcon />}
@@ -186,7 +186,7 @@ const UploadProfilePictureModal = ({
       </Box>
       <Typography
         sx={{
-          color: theme.palette[role].Default,
+          color: theme.palette[role].Dark.Default,
           textAlign: "center",
           fontSize: "12.5px",
           fontWeight: 100,

--- a/frontend/src/components/user_management/UserTable.tsx
+++ b/frontend/src/components/user_management/UserTable.tsx
@@ -1,20 +1,20 @@
-import React from "react";
+import { Delete } from "@mui/icons-material";
 import {
-  TableContainer,
+  Avatar,
+  Box,
+  Button,
   Paper,
   Table,
   TableBody,
-  TableRow,
   TableCell,
-  Avatar,
-  Box,
-  Typography,
+  TableContainer,
   TableFooter,
   TablePagination,
-  Button,
+  TableRow,
+  Typography,
 } from "@mui/material";
 import { useTheme } from "@mui/material/styles";
-import { Delete } from "@mui/icons-material";
+import React from "react";
 import { User } from "../../types/UserTypes";
 import placeholderImage from "../assets/placeholder_profile.png";
 
@@ -101,8 +101,8 @@ const UserTable: React.FC<UserTableProps> = ({
                   sx={{
                     marginRight: "16px",
                     display: "inline-block",
-                    backgroundColor: theme.palette[user.role].Light,
-                    color: theme.palette[user.role].Default,
+                    backgroundColor: theme.palette[user.role].Light.Default,
+                    color: theme.palette[user.role].Dark.Default,
                   }}
                 >
                   {user.role.toUpperCase()}
@@ -115,7 +115,7 @@ const UserTable: React.FC<UserTableProps> = ({
                     padding: "4px 16px",
                     borderRadius: "4px",
                     borderColor: theme.palette.Neutral[500],
-                    color: theme.palette.Error.Default,
+                    color: theme.palette.Error.Dark.Default,
                   }}
                   onClick={() =>
                     handleOpenDeleteUserModal(

--- a/frontend/src/theme/theme.ts
+++ b/frontend/src/theme/theme.ts
@@ -1,67 +1,105 @@
+import "@fontsource/lexend-deca";
 import {
   createTheme,
   PaletteOptions,
   TypographyOptions,
 } from "@mui/material/styles";
-import "@fontsource/lexend-deca";
 
 const palette: PaletteOptions = {
   Learner: {
-    Light: "#F5FDFF",
-    Hover: "#CCF5FF",
-    Default: "#006877",
-    Pressed: "#00363F",
-  },
-  NewLearnerLight: {
-    Default: "#F5FDFF",
-    Selected: "#CCF5FF",
-    Pressed: "#D8EAEF",
-    Hover: "#E5F5F9",
-  },
-  NewLearnerDark: {
-    Default: "#006877",
-    Selected: "#00515C",
-    Pressed: "#3F5053",
-    Hover: "#416166",
+    Light: {
+      Default: "#E8FCFF",
+      Hover: "#CCF8FF",
+      Selected: "#AFF0FA",
+      Pressed: "#90E3F0",
+    },
+    Dark: {
+      Default: "#006C7D",
+      Hover: "#004D59",
+      Selected: "#003942",
+      Pressed: "#002E36",
+    },
   },
   Administrator: {
-    Light: "#FFF8F6",
-    Hover: "#FFD9CC",
-    Default: "#8F4C34",
-    Pressed: "#5C1900",
+    Light: {
+      Default: "#FFE6DD",
+      Hover: "#FCC4B1",
+      Selected: "#FFD9CC",
+      Pressed: "#000000",
+    },
+    Dark: {
+      Default: "#8F4C34",
+      Hover: "#663625",
+      Selected: "#4D281C",
+      Pressed: "#3C2016",
+    },
   },
   Facilitator: {
-    Light: "#F9F5FF",
-    Hover: "#D6D6FF",
-    Default: "#555A92",
-    Pressed: "#1F257A",
-  },
-  Error: {
-    Light: "#FFF2F0",
-    Hover: "#FFD1CC",
-    Default: "#BA1A1A",
-    Pressed: "#690005",
-  },
-  Success: {
-    Light: "#FDFFF0",
-    Hover: "#FAFFCC",
-    Default: "#687021",
-    Pressed: "#444B04",
-  },
-  Warning: {
-    Light: "#FFFBEF",
-    Hover: "#FFF2CC",
-    Default: "#775900",
-    Pressed: "#3F2F00",
+    Light: {
+      Default: "#F2F3FF",
+      Hover: "#E5E7FF",
+      Selected: "#D9DBFF",
+      Pressed: "#CACDFC",
+    },
+    Dark: {
+      Default: "#4F549E",
+      Hover: "#32377D",
+      Selected: "#1F2469",
+      Pressed: "#191D54",
+    },
   },
   Neutral: {
     100: "#FFFFFF",
-    200: "#F8FAFA",
-    300: "#E4E5E5",
-    400: "#CACCCC",
-    500: "#6F797B",
-    600: "#404B4D",
-    700: "#111111",
+    200: "#F2F2F2",
+    300: "#D1D2D4",
+    400: "#B2B3B5",
+    500: "#919295",
+    600: "#7A7C7F",
+    700: "#555759",
+    800: "#4A4C4D",
+    900: "#111111",
+  },
+  Success: {
+    Light: {
+      Default: "#FAFFEF",
+      Hover: "#EAFAC8",
+      Selected: "#E0F7AD",
+      Pressed: "#D4F291",
+    },
+    Dark: {
+      Default: "#486902",
+      Hover: "#385200",
+      Selected: "#2A3D00",
+      Pressed: "#213000",
+    },
+  },
+  Error: {
+    Light: {
+      Default: "#FFEFEF",
+      Hover: "#FFE0E0",
+      Selected: "#FFD4D4",
+      Pressed: "#FFBDBD",
+    },
+    Dark: {
+      Default: "#AD2323",
+      Hover: "#801313",
+      Selected: "#610A0A",
+      Pressed: "#540000",
+    },
+  },
+  Warning: {
+    Light: {
+      Default: "#FFF5E0",
+      Hover: "#FFEABF",
+      Selected: "#FFDD99",
+      Pressed: "#FFCC66",
+    },
+    Dark: {
+      Default: "#693902",
+      Hover: "#522C00",
+      Selected: "#3D2100",
+      Pressed: "#301A00",
+    },
   },
 };
 

--- a/frontend/src/theme/themeAugmentation.d.ts
+++ b/frontend/src/theme/themeAugmentation.d.ts
@@ -1,8 +1,4 @@
-import {
-  PaletteColor,
-  PaletteColorOptions,
-  TypographyOptions,
-} from "@mui/material/styles";
+import "@mui/material/styles";
 
 declare module "@mui/material/styles" {
   interface PaletteColorOptions {
@@ -19,15 +15,22 @@ declare module "@mui/material/styles" {
     Hover: string;
   }
 
+  interface UserShadeColorOptions {
+    Default: string;
+    Hover: string;
+    Selected: string;
+    Pressed: string;
+  }
+
+  interface UserColorOptions {
+    Light: UserShadeColorOptions;
+    Dark: UserShadeColorOptions;
+  }
+
   interface PaletteOptions {
-    Learner: PaletteColorOptions;
-    NewLearnerLight: NewPaletteColorOptions;
-    NewLearnerDark: NewPaletteColorOptions;
-    Administrator: PaletteColorOptions;
-    Facilitator: PaletteColorOptions;
-    Error: PaletteColorOptions;
-    Success: PaletteColorOptions;
-    Warning: PaletteColorOptions;
+    Learner: UserColorOptions;
+    Administrator: UserColorOptions;
+    Facilitator: UserColorOptions;
     Neutral: {
       100: string;
       200: string;
@@ -36,7 +39,12 @@ declare module "@mui/material/styles" {
       500: string;
       600: string;
       700: string;
+      800: string;
+      900: string;
     };
+    Success: UserColorOptions;
+    Error: UserColorOptions;
+    Warning: UserColorOptions;
   }
 
   interface TypographyOptions {


### PR DESCRIPTION
Switched to `[User].[Light|Dark].[Default|Hover|Selected|Pressed]` colour scheme.

## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Update Colours to match new Figma](https://www.notion.so/uwblueprintexecs/Update-Colours-to-match-new-Figma-27610f3fb1dc81869470de0cbd05e155)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Updated `theme.ts` to add all new colours
* Updated all references to old variables in `theme.ts`

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Check that linting and type-checking is ok :+1:


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
